### PR TITLE
meson: fix soname

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ m_dep = cc.find_library('m', required : false)
 shared_library(
   meson.project_name(),
   sources,
+  version: '1',
   dependencies: [
     m_dep,
     dependency('avahi-client'),


### PR DESCRIPTION
The output was named libsane-airscan.so instead of libsane-airscan.so.1
