### PR TITLE
Update Readme with Epson XP 8600 Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ into this list, please let me know.
 * Canon TS 6250
 * EPSON WF-7710
 * EPSON XP-7100 Series
+* EPSON XP-8600 Series
 * HP Color Laserjet MFP m178-m181
 * HP Color LaserJet MFP M281fdw
 * HP DeskJet 2540


### PR DESCRIPTION
The eSCL driver works perfectly fine with
the Epson XP 8600 series.