### PR TITLE
airscan-mdns: fix segmentation fault if event is AVAHI_RESOLVER_FAILURE

### DIFF
--- a/airscan-mdns.c
+++ b/airscan-mdns.c
@@ -603,9 +603,11 @@ mdns_avahi_resolver_callback (AvahiServiceResolver *r,
         }
     }
 
-    /* Notify WSDD about newly discovered address */
-    af = addr->proto == AVAHI_PROTO_INET ? AF_INET : AF_INET6;
-    wsdd_send_directed_probe(interface, af, &addr->data);
+    if (event == AVAHI_RESOLVER_FOUND) {
+        /* Notify WSDD about newly discovered address */
+        af = addr->proto == AVAHI_PROTO_INET ? AF_INET : AF_INET6;
+        wsdd_send_directed_probe(interface, af, &addr->data);
+    }
 }
 
 /* AVAHI browser callback


### PR DESCRIPTION
In case of an error (timeout), addr is NULL and causes a null pointer dereference.