### PR TITLE
Makefile: use ldflags for linking airscan-discover too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(BACKEND): $(OBJDIR)airscan.o $(LIBAIRSCAN) airscan.sym
 	$(CC) -o $(BACKEND) -shared $(OBJDIR)/airscan.o $(LIBAIRSCAN) $(airscan_LDFLAGS)
 
 $(DISCOVER): $(OBJDIR)discover.o $(LIBAIRSCAN)
-	 $(CC) -o $(DISCOVER) discover.c $(CPPFLAGS) $(airscan_CFLAGS) $(LIBAIRSCAN) $(airscan_LIBS) -fPIE
+	 $(CC) -o $(DISCOVER) discover.c $(CPPFLAGS) $(airscan_CFLAGS) $(LIBAIRSCAN) $(airscan_LIBS) $(LDFLAGS) -fPIE
 
 $(LIBAIRSCAN): $(OBJ) Makefile
 	ar cru $(LIBAIRSCAN) $(OBJ)


### PR DESCRIPTION
Hi,

buildsystems add several linking flags depending on OS - Makefile should be capable to pass them to all executables and libraries which are built.

airscan-discover wasn't built with OS buildsystem LDFLAGS, because $(LDFLAGS) is missing from invocation.

Would you mind adding the patch to the project? Please let me know if I should change something.

Thank you in advance,

Zdenek