### PR TITLE
README: Add HP OfficeJet Pro 8020 Series as a Supported eSCL Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Legend:
 | HP Officejet 4630                  | Yes                       |                           |
 | HP Officejet Pro 6970              | Yes                       |                           |
 | HP OfficeJet Pro 6978              | Yes                       |                           |
+| HP OfficeJet Pro 8020 Series       | Yes                       |                           |
 | HP OfficeJet Pro 8730              | Yes                       | Yes                       |
 | HP OfficeJet Pro 9010 series       | Yes                       |                           |
 | HP Smart Tank Plus 550 series      | Yes                       |                           |


### PR DESCRIPTION
I ran the the [Installation from pre-build binaries](https://github.com/alexpevzner/sane-airscan#installation-from-pre-build-binaries) steps on Ubuntu 18.04 and then ran

`scanimage -L`

and the output immediately picked up the HP OfficeJet Pro 8020 series scanner.

> device `airscan:e0:HP OfficeJet Pro 8020 series [72CF42]' is a eSCL HP OfficeJet Pro 8020 series [72CF42] eSCL network scanner

I was able to scan a document using scanimage.

The actual model used to test is a 8028, which is the Costco version of the printer.  However, it looks as though 8020, 8022, 8023, 8024, 8025, 8026, 8028 are the currently produced sub-models under the 8020 series and one would assume all of these 802**x** models would work just the same.