### PR TITLE
README: Add Brother MFC-L2700DW as supported WSD device

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Legend:
 
 | Device                             | eSCL mode                 | WSD mode                  |
 | ---------------------------------- | :-----------------------: | :-----------------------: |
+| Brother MFC-L2700DW                |                           | Yes                       |
 | Brother MFC-L2710DW                | Yes                       | Yes                       |
 | Brother MFC-L2720DW                | No                        | Yes                       |
 | Brother MFC-L2750DW                | Yes                       | Yes                       |


### PR DESCRIPTION
Hi,

i installed the binary fedora32 version. Running scanimage detects my MFC-L2700DW as a WSD capable network scanner.

`> scanimage -L
device `airscan:w0:Brother MFC-L2700DW series' is a WSD Brother MFC-L2700DW series WSD network scanner
`

Scanning using this device works flawless so far.

Thank you!