### PR TITLE
Add new .c files to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ sources = [
   'airscan-escl.c',
   'airscan-http.c',
   'airscan-id.c',
+  'airscan-inifile.c',
+  'airscan-init.c',
   'airscan-ip.c',
   'airscan-jpeg.c',
   'airscan-log.c',


### PR DESCRIPTION
Adds the inifile and init .c files to meson.build so that the meson
build doesn't fail with undefined symbol errors at link-time.