### PR TITLE
Link libpthread (minor fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ OBJ	= $(addprefix $(OBJDIR), $(SRC:.c=.o))
 deps_CFLAGS		:= $(foreach lib, $(DEPS_COMMON), $(shell $(PKG_CONFIG) --cflags $(lib)))
 deps_CFLAGS		+= $(foreach lib, $(DEPS_CODECS), $(shell $(PKG_CONFIG) --cflags $(lib)))
 
-deps_LIBS 		:= $(foreach lib, $(DEPS_COMMON), $(shell $(PKG_CONFIG) --libs $(lib))) -lm
+deps_LIBS 		:= $(foreach lib, $(DEPS_COMMON), $(shell $(PKG_CONFIG) --libs $(lib))) -lm -lpthread
 deps_LIBS_CODECS 	:= $(foreach lib, $(DEPS_CODECS), $(shell $(PKG_CONFIG) --libs $(lib)))
 
 # Compute CFLAGS and LDFLAGS for backend and tools


### PR DESCRIPTION
```gcc -o test-zeroconf test-zeroconf.c -O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4 -m64 -mtune=generic -O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4 -m64 -mtune=generic  -D_REENTRANT  -I/usr/include/libxml2  -I/usr/include/p11-kit-1    -I/usr/include/libpng16 -fPIC objs//libairscan.a  -lavahi-common -lavahi-client  -lxml2  -lgnutls -lm -fPIE  -ljpeg  -lpng16 -lz
/usr/bin/x86_64-openmandriva-linux-gnu-ld: objs//libairscan.a(airscan-eloop.o): undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
/usr/bin/x86_64-openmandriva-linux-gnu-ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
```
(building on rosa2019.1 with system CFLAGS, which protect from underlinking by default)