### PR TITLE
Mark Brother DCP-L2550DN as tested in eSCL mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Legend:
 | Device                             | eSCL mode                 | WSD mode                  |
 | ---------------------------------- | :-----------------------: | :-----------------------: |
 | Brother DCP-L2540DW                | No                        | Yes                       |
-| Brother DCP-L2550DW                | Yes                       |                           |
+| Brother DCP-L2550DN / DCP-L2550DW  | Yes                       |                           |
 | Brother MFC-J485DW                 | Yes                       |                           |
 | Brother MFC-L2700DW                | No                        | Yes                       |
 | Brother MFC-L2710DW                | Yes                       | Yes                       |


### PR DESCRIPTION
I merged the two DCP-L2550D* in one line as they're very likely quite similar models, at least in terms of scanning.