### PR TITLE
RFC: Add demonstration fuzzers

### DIFF
--- a/FUZZER.md
+++ b/FUZZER.md
@@ -1,0 +1,16 @@
+The `fuzzer` directory contains several fuzz targets that make use of asan and
+[libFuzzer](https://llvm.org/docs/LibFuzzer.html) from clang 10 or later to test
+functions that are expected to process untrusted inputs.
+
+To build:
+
+```
+CXX=clang++-10 meson build
+ninja -C build fuzzer-$name
+```
+
+where `$name` can be any of the files in the `fuzzer` directory.
+
+You can then run the fuzzer as `build/fuzzer-$name`.  The basic mode will run
+indefinitely until a problem is found.  Pass `-help=1` to see additional fuzzer
+options.

--- a/fuzzer/query.cc
+++ b/fuzzer/query.cc
@@ -1,0 +1,108 @@
+// Copyright 2020 The Chromium OS Authors. All rights reserved.
+// See LICENSE for license terms and conditions.
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include "airscan.h"
+
+constexpr int kMaxInputSize = 32 * 1024;
+
+namespace {
+
+struct LogWrapper {
+  LogWrapper() { log_init(); }
+  ~LogWrapper() { log_cleanup(); }
+};
+
+struct EventLoop {
+  EventLoop() { eloop_init(); }
+  ~EventLoop() { eloop_cleanup(); }
+};
+
+class LogContext {
+ public:
+  LogContext() : ctx_(log_ctx_new("http fuzzer", nullptr)) {}
+  ~LogContext() { log_ctx_free(ctx_); }
+  log_ctx *get() { return ctx_; }
+
+ private:
+  log_ctx *ctx_;
+};
+
+class HttpClient {
+ public:
+  explicit HttpClient(log_ctx *ctx) : client_(http_client_new(ctx, nullptr)) {}
+  ~HttpClient() { http_client_free(client_); }
+  http_client *get() { return client_; }
+
+ private:
+  http_client *client_;
+};
+
+void query_callback(void *, http_query *) {}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Limit fuzzer input size to 32KB.
+  if (size > kMaxInputSize) {
+    return 0;
+  }
+
+  LogWrapper log;
+  EventLoop loop;
+
+  LogContext ctx;
+  if (!ctx.get()) {
+    return 0;
+  }
+
+  HttpClient client(ctx.get());
+  if (!client.get()) {
+    return 0;
+  }
+
+  FuzzedDataProvider provider(data, size);
+  std::string uri_str = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  http_uri *uri = http_uri_new(uri_str.c_str(), provider.ConsumeBool());
+  if (!uri) {
+    return 0;
+  }
+
+  std::string method = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  std::string body = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  std::string content_type = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+
+  // str_dup() is airscan's internal string copy function which uses mem_new().
+  // Only body needs to be copied, since http_query_new() takes ownership.
+  http_query *query =
+      http_query_new(client.get(), uri, method.c_str(), str_dup(body.c_str()),
+                     content_type.c_str());
+
+  std::string unset_field = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  http_query_get_request_header(query, unset_field.c_str());
+
+  std::string set_field = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  std::string value = provider.ConsumeRandomLengthString(
+      provider.remaining_bytes());
+  http_query_set_request_header(query, set_field.c_str(), value.c_str());
+  http_query_get_request_header(query, set_field.c_str());
+
+  http_query_status(query);
+  http_query_status_string(query);
+
+  http_query_submit(query, &query_callback);
+
+  http_client_cancel(client.get());
+  return 0;
+}

--- a/fuzzer/uri.cc
+++ b/fuzzer/uri.cc
@@ -1,0 +1,74 @@
+// Copyright 2020 The Chromium OS Authors. All rights reserved.
+// See LICENSE for license terms and conditions.
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include "airscan.h"
+
+constexpr int kMaxInputSize = 32 * 1024;
+
+namespace {
+
+struct LogWrapper {
+  LogWrapper() { log_init(); }
+  ~LogWrapper() { log_cleanup(); }
+};
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // Limit fuzzer input size to 32KB.  URLs technically don't have a limit, but
+  // practical sizes found in real life will be under 4KB.  This gives us a
+  // buffer to test longer URLs without wasting time on huge inputs.
+  if (size > kMaxInputSize) {
+    return 0;
+  }
+
+  FuzzedDataProvider data_provider(data, size);
+  std::string str_input = data_provider.ConsumeRemainingBytesAsString();
+
+  LogWrapper log;
+
+  http_uri *uri1 = http_uri_new(str_input.c_str(), true);
+  if (uri1 == NULL) {
+    return 0;
+  }
+  http_uri_free(uri1);
+
+  uri1 = http_uri_new(str_input.c_str(), false);
+  if (uri1 == NULL) {
+    return 0;
+  }
+
+  http_uri *uri2 = http_uri_clone(uri1);
+  if (uri2 == NULL) {
+    http_uri_free(uri1);
+    return 0;
+  }
+  http_uri_free(uri2);
+
+  const char *str = http_uri_str(uri1);
+  uri2 = http_uri_new(str, true);
+  if (uri2 == NULL) {
+    http_uri_free(uri1);
+    return 0;
+  }
+  http_uri_free(uri2);
+
+  const char *path = http_uri_get_path(uri1);
+  uri2 = http_uri_new_relative(uri1, path, false, false);
+  if (uri2 == NULL) {
+    http_uri_free(uri1);
+    return 0;
+  }
+  http_uri_free(uri2);
+
+  http_uri_fix_end_slash(uri1);
+  http_uri_free(uri1);
+
+  return 0;
+}

--- a/fuzzer/xml.cc
+++ b/fuzzer/xml.cc
@@ -1,0 +1,42 @@
+// Copyright 2020 The Chromium OS Authors. All rights reserved.
+// See LICENSE for license terms and conditions.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include <libxml/xmlerror.h>
+
+#include "airscan.h"
+
+void noerrs(void *ctx, const char*msg, ...) {
+  // Ignore the libxml error messages.
+}
+
+constexpr int kMaxInputSize = 32 * 1024;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // Limit fuzzer input size to 32KB.  libxml can take a very long time to
+  // parse very large inputs, which causes the fuzzer to time out.
+  if (size > kMaxInputSize) {
+    return 0;
+  }
+
+  xmlSetGenericErrorFunc(NULL, noerrs);
+
+  xml_rd *xml = NULL;
+  if (xml_rd_begin(&xml, (const char*)data, size, NULL)) {
+    return 0;
+  }
+  if (xml == NULL) {
+    return 0;
+  }
+
+  while (!xml_rd_end(xml)) {
+    xml_rd_deep_next(xml, 0);
+  }
+
+  xml_rd_finish(&xml);
+
+  return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('sane-airscan', 'c')
+project('sane-airscan', 'c', 'cpp')
 
 sources = [
   'airscan-array.c',
@@ -75,6 +75,17 @@ dll_file = configure_file(
   output: 'airscan',
   copy: true
 )
+
+foreach fuzzer : ['uri', 'xml']
+  executable(
+    'fuzzer-' + fuzzer,
+    sources + ['fuzzer/@0@.cc'.format(fuzzer)],
+    dependencies: shared_deps,
+    build_by_default: false,
+    cpp_args: ['-fsanitize=address', '-fsanitize=fuzzer-no-link'],
+    link_args: ['-fsanitize=address', '-fsanitize=fuzzer']
+  )
+endforeach
 
 install_man('sane-airscan.5')
 install_man('airscan-discover.1')

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,7 @@ dll_file = configure_file(
   copy: true
 )
 
-foreach fuzzer : ['uri', 'xml']
+foreach fuzzer : ['query', 'uri', 'xml']
   executable(
     'fuzzer-' + fuzzer,
     sources + ['fuzzer/@0@.cc'.format(fuzzer)],


### PR DESCRIPTION
This probably isn't ready to merge, but I wanted to send it for discussion as promised in #88.  I've only added the targets to meson for now.  If you like the general concept, we can do a more thorough job.

The basic idea is to fuzz functions that might process untrusted data.  The fuzzer uses code coverage information to generate inputs that gradually exercise more and more code paths.  It emits a reproduction case whenever it finds a crash or an asan failure. 

We want to start at high-level functions so that functions get called in the same way the code uses them, but we also don't want the fuzzer to trigger side effects or failures caused by external setup.  I've used functions defined in airscan.h as a heuristic for things that are likely to be around that level.  I didn't attempt to directly fuzz static functions from the various c files because I'm assuming they are protected by validation in the exposed functions.  It should also be possible to fuzz the real entry points if desired, but then the fuzzer will also explore libsane, libavahi, and whatever other code might be reachable from there.  Hopefully this presents a reasonable tradeoff of focus vs mostly reasonable API use.

To compile:
  * CXX=clang++ meson build
  * ninja -C build airscan_xml_fuzzer airscan_uri_fuzzer

These fuzzers use libfuzzer and asan support in clang 10 or later to
fuzz the XML parsing and http_uri functions.  They aren't very thorough
(yet), but demonstrate the basic technique.