### PR TITLE
Clarify fuzzer license

### DIFF
--- a/fuzzer/query.cc
+++ b/fuzzer/query.cc
@@ -1,5 +1,5 @@
 // Copyright 2020 The Chromium OS Authors. All rights reserved.
-// See LICENSE for license terms and conditions.
+// See the sane-airscan top-level LICENSE for license terms and conditions.
 
 #include <fuzzer/FuzzedDataProvider.h>
 

--- a/fuzzer/uri.cc
+++ b/fuzzer/uri.cc
@@ -1,5 +1,5 @@
 // Copyright 2020 The Chromium OS Authors. All rights reserved.
-// See LICENSE for license terms and conditions.
+// See the sane-airscan top-level LICENSE for license terms and conditions.
 
 #include <fuzzer/FuzzedDataProvider.h>
 

--- a/fuzzer/xml.cc
+++ b/fuzzer/xml.cc
@@ -1,5 +1,5 @@
 // Copyright 2020 The Chromium OS Authors. All rights reserved.
-// See LICENSE for license terms and conditions.
+// See the sane-airscan top-level LICENSE for license terms and conditions.
 
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
The LICENSE file mentioned in fuzzer headers was meant to refer to the
main sane-airscan license, not a potentially separate fuzzer license.

Fixes #100.