### PR TITLE
Compress without embedded timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@
 #   CPPFLAGS                            C preprocessor flags
 #   CFLAGS     -O2 -g -W -Wall -Werror  C compiler flags
 #   LDFLAGS                             Linker flags
-#   COMPRESS   gzip                     Program to compress man page, or ""
+#   COMPRESS   gzip -n                  Program to compress man page, or ""
 #   MANDIR     /usr/share/man/          Where to install man page
 #   STRIP      -s                       Stripping of debug symbols
 #   PKG_CONFIG pkg-config               Program to query dependencies info
 #   INSTALL    install                  Installation program
 
 CC	= gcc
-COMPRESS = gzip
+COMPRESS = gzip -n
 CFLAGS	+= -O2 -g -W -Wall -Werror -pthread $(CPPFLAGS)
 MANDIR	= /usr/share/man/
 PKG_CONFIG = /usr/bin/pkg-config


### PR DESCRIPTION
This solves a reproducible builds issue: https://reproducible.archlinux.org/api/v0/builds/3156/diffoscope

```
│ ├── usr/share/man/man1/airscan-discover.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "airscan-discover.1", last modified: Mon Nov 23 21:29:37 2020, from Unix
│ │ │ +gzip compressed data, was "airscan-discover.1", last modified: Fri Nov 27 14:04:42 2020, from Unix
│ ├── usr/share/man/man5/sane-airscan.5.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "sane-airscan.5", last modified: Mon Nov 23 21:29:37 2020, from Unix
│ │ │ +gzip compressed data, was "sane-airscan.5", last modified: Fri Nov 27 14:04:42 2020, from Unix
```