### PR TITLE
airscan.conf: comment out lines from blacklist

### DIFF
--- a/airscan.conf
+++ b/airscan.conf
@@ -80,9 +80,9 @@
 #   Blacklisting only affects automatic discovery, and doesn't
 #   affect manually configured devices
 [blacklist]
-model = "Xerox*"       ; blacklist by model name
-name  = "HP*"          ; blacklist by network name
-ip    = 192.168.0.1    ; blacklist by address
-ip    = 192.168.0.0/24 ; blacklist the whole subnet
+#model = "Xerox*"       ; blacklist by model name
+#name  = "HP*"          ; blacklist by network name
+#ip    = 192.168.0.1    ; blacklist by address
+#ip    = 192.168.0.0/24 ; blacklist the whole subnet
 
 


### PR DESCRIPTION
Those lines looks like examples, so let's comment them out to prevent problems with Xerox and HP device discovery :) .