### PR TITLE
Add HP OfficeJet Pro 7740

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Legend:
 | HP Officejet 4630                  | Yes                       |                           |
 | HP Officejet Pro 6970              | Yes                       |                           |
 | HP OfficeJet Pro 6978              | Yes                       |                           |
+| HP OfficeJet Pro 7740              | Yes                       |                           |
 | HP OfficeJet Pro 8010 series       | Yes                       |                           |
 | HP OfficeJet Pro 8020 Series       | Yes                       |                           |
 | HP OfficeJet Pro 8730              | Yes                       | Yes                       |


### PR DESCRIPTION
Output of `scanimage -L`:
```
device `escl:https://192.168.1.102:443' is a HP OfficeJet Pro 7740 series [BBAE2F] platen,adf scanner
device `airscan:e0:HP OfficeJet Pro 7740 series [BBAE2F]' is a eSCL HP OfficeJet Pro 7740 series [BBAE2F] ip=192.168.1.102
```

I didn't test WSD as it wasn't displayed, so I assume it's not supported either.