### PR TITLE
Add quirk to force port in Host header

### DIFF
--- a/airscan-http.c
+++ b/airscan-http.c
@@ -1971,6 +1971,7 @@ struct http_query {
     http_hdr          request_header;           /* Request header */
     http_hdr          response_header;          /* Response header */
     bool              host_inserted;            /* Host: auto-inserted */
+    bool              force_port;               /* Host: always includes port */
 
     /* HTTP redirects */
     int               redirect_count;           /* Count of redirects */
@@ -2126,6 +2127,9 @@ http_query_set_host (http_query *q)
             dport = -1;
             break;
         }
+        if (q->force_port) {
+            dport = -1;
+        }
 
         s = ip_straddr_from_sockaddr_dport(addr, dport, false);
         http_query_set_request_header(q, "Host", s.text);
@@ -2270,6 +2274,16 @@ http_query_timeout_cancel (http_query *q)
         eloop_timer_cancel(q->timeout_timer);
         q->timeout_timer = NULL;
     }
+}
+
+/* Set forcing port to be added to the Host header for this query.
+ *
+ * This function may be called multiple times (each subsequent call overrides
+ * a previous one).
+ */
+void
+http_query_force_port(http_query *q, bool force_port) {
+    q->force_port = force_port;
 }
 
 /* For this particular query override on-error callback, previously

--- a/airscan.h
+++ b/airscan.h
@@ -1798,6 +1798,14 @@ http_query_new_relative(http_client *client,
 void
 http_query_timeout (http_query *q, int timeout);
 
+/* Set forcing port to be added to the Host header for this query.
+ *
+ * This function may be called multiple times (each subsequent call overrides
+ * a previous one).
+ */
+void
+http_query_force_port(http_query *q, bool force_port);
+
 /* For this particular query override on-error callback, previously
  * set by http_client_onerror()
  *


### PR DESCRIPTION
Some devices rely on finding the port in the Host HTTP header to
construct their response to the /eSCL/ScanJobs request.  When the port
isn't included, the steps up to the scan job creation work, but an
invalid redirect will be sent in the response to /eSCL/ScanJobs and then
the scan job will never finish.

Add a new quirk that forces the port to always be included in the Host
header.  This is known to affect some Epson models, and Epson has
indicated that this should be safe to use with all of their devices, so
enable it for eSCL whenever the manufacturer is Epson.  The quirk itself
is generic so that it can easily be enabled for more devices in the
future if needed.

Tested on a ET-3750.
Fixes #136.