### PR TITLE
HP OfficeJet 7740 Pro:  Document no WSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Legend:
 | HP Officejet 4630                  | Yes                       |                           |
 | HP Officejet Pro 6970              | Yes                       |                           |
 | HP OfficeJet Pro 6978              | Yes                       |                           |
-| HP OfficeJet Pro 7740              | Yes                       |                           |
+| HP OfficeJet Pro 7740              | Yes                       | No                        |
 | HP OfficeJet Pro 8010 series       | Yes                       |                           |
 | HP OfficeJet Pro 8020 Series       | Yes                       |                           |
 | HP OfficeJet Pro 8730              | Yes                       | Yes                       |


### PR DESCRIPTION
From #134 :

> To test with WSD, you need to set `protocol = manual` in the `/etc/sane.d/airscan.conf`. By default, all entries corresponding to the same physical device are merged and protocol is chosen automatically, so in the default configuration you will see only one device/protocol in the list (eSCL is preferred over WSD if both are available)

I tested with `scanimage -L` with the changed configuration and had the same output (no entry other than eSCL).