### PR TITLE
airscan-trace.c: Check the path length

### DIFF
--- a/airscan-trace.c
+++ b/airscan-trace.c
@@ -110,6 +110,9 @@ trace_open (const char *device_name)
     path = str_append(path, ".log");
     t->log = fopen(path, "w");
 
+    // work around gcc 11 warning
+    log_assert(NULL, str_len(path) >= 4);
+
     strcpy(path + str_len(path) - 4, ".tar");
     t->data = fopen(path, "wb");
 


### PR DESCRIPTION
GCC 11 with -Werror generates an error for 'strcpy' usage, so checking
the size and returning NULL if lesser than 4 works it around.