### PR TITLE
Expose width justification option to sane-airscan

### DIFF
--- a/airscan-devops.c
+++ b/airscan-devops.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 /* Static variables */
 static const SANE_Range devopt_percent_range = {
     .min = SANE_FIX(-100.0),
@@ -379,6 +378,15 @@ devopt_rebuild_opt_desc (devopt *opt)
     desc->type = SANE_TYPE_BOOL;
     desc->size = sizeof(SANE_Bool);
     desc->cap = SANE_CAP_SOFT_SELECT | SANE_CAP_SOFT_DETECT | SANE_CAP_EMULATED;
+
+    /* OPT_JUSTIFICATION */
+    desc = &opt->desc[OPT_JUSTIFICATION_X];
+    desc->name = SANE_NAME_ADF_JUSTIFICATION_X;
+    desc->title = SANE_TITLE_ADF_JUSTIFICATION_X;
+    desc->desc = SANE_DESC_ADF_JUSTIFICATION_X;
+    desc->type = SANE_TYPE_STRING;
+    desc->size = sane_string_array_max_strlen(opt->sane_sources) + 1;
+    desc->cap = SANE_CAP_SOFT_DETECT;
 }
 
 /* Update scan parameters, according to the currently set
@@ -617,6 +625,7 @@ devopt_set_defaults (devopt *opt)
     opt->highlight = SANE_FIX(100.0);
     opt->gamma = SANE_FIX(1.0);
 
+
     devopt_rebuild_opt_desc(opt);
     devopt_update_params(opt);
 }
@@ -759,6 +768,10 @@ devopt_get_option (devopt *opt, SANE_Int option, void *value)
 
     case OPT_NEGATIVE:
         *(SANE_Bool*)value = opt->negative;
+        break;
+
+    case OPT_JUSTIFICATION_X:
+        strcpy(value, id_justification_x_sane_name(opt->caps.justification_x));
         break;
 
     default:

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -177,6 +177,36 @@ id_format_short_name (ID_FORMAT id)
     return name ? name : mime;
 }
 
+
+/******************** ID_JUSTIFICATION_X ********************/
+/* id_justification_x_sane_name_table represents ID_JUSTIFICATION_X to
+ * SANE name mapping
+ */
+static id_name_table id_justification_x_sane_name_table[] = {
+    {ID_JUSTIFICATION_X_LEFT,     OPTVAL_JUSTIFICATION_X_LEFT},
+    {ID_JUSTIFICATION_X_CENTER,   OPTVAL_JUSTIFICATION_X_CENTER},
+    {ID_JUSTIFICATION_X_RIGHT,    OPTVAL_JUSTIFICATION_X_RIGHT},
+    {SANE_CAP_INACTIVE,           OPTVAL_JUSTIFICATION_X_NONE}
+};
+
+/* id_justification_x_sane_name returns SANE name for the justification
+ * For unknown ID returns NULL
+ */
+const char*
+id_justification_x_sane_name (ID_JUSTIFICATION_X id)
+{
+    return id_name(id, id_justification_x_sane_name_table);
+}
+
+/* id_justification_x_by_sane_name returns ID_JUSTIFICATION_X by its SANE name
+ * For unknown name returns ID_JUSTIFICATION_UNKNOWN
+ */
+ID_JUSTIFICATION_X
+id_justification_x_by_sane_name (const char *name)
+{
+    return id_by_name(name, strcasecmp, id_justification_x_sane_name_table);
+}
+
 /******************** PROTO_OP ********************/
 /* proto_op_name_table represents PROTO_OP to its
  * name mappind

--- a/airscan-wsd.c
+++ b/airscan-wsd.c
@@ -578,6 +578,7 @@ wsd_devcaps_decode (const proto_ctx *ctx, devcaps *caps)
 
     caps->units = 1000;
     caps->protocol = ctx->proto->name;
+    caps->justification_x = SANE_CAP_INACTIVE;
 
     err = wsd_devcaps_parse(wsd, caps, data->bytes, data->size);
 

--- a/airscan.c
+++ b/airscan.c
@@ -120,7 +120,16 @@ void
 sane_close (SANE_Handle handle)
 {
     device  *dev = (device*) handle;
-
+    
+    //TODO: erase; temp for checking devcaps
+    log_debug(device_log_ctx(dev), "API: justifi called: start");
+    char justval[256] = ""; // TODO: fix :) 
+    device_get_option(dev, OPT_JUSTIFICATION_X, &justval);
+    log_debug(device_log_ctx(dev), "API: justifi called, value: ");
+    // if(justval == OPTVAL_JUSTIFICATION_X_NONE){
+        log_debug(device_log_ctx(dev), justval);
+    // }
+    
     log_debug(device_log_ctx(dev), "API: sane_close(): called");
 
     eloop_mutex_lock();

--- a/airscan.h
+++ b/airscan.h
@@ -81,6 +81,12 @@ typedef struct http_uri http_uri;
 #define OUTER_STRUCT(member_p,struct_t,field)                            \
     ((struct_t*)((char*)(member_p) - ((ptrdiff_t) &(((struct_t*) 0)->field))))
 
+/* Define option not included in saneopts */
+#define SANE_NAME_ADF_JUSTIFICATION_X       "adf-justification-x"
+#define SANE_TITLE_ADF_JUSTIFICATION_X      SANE_I18N("ADF Width Justification")
+#define SANE_DESC_ADF_JUSTIFICATION_X       SANE_I18N("Width justification options for ADF")
+
+
 /******************** Circular Linked Lists ********************/
 /* ll_node represents a linked data node.
  * Data nodes are embedded into the corresponding data structures:
@@ -717,6 +723,27 @@ id_source_sane_name (ID_SOURCE id);
  */
 ID_SOURCE
 id_source_by_sane_name (const char *name);
+
+/* ID_JUSTIFICATION_X represents potential ADF justification
+ */
+typedef enum {
+    ID_JUSTIFICATION_X_LEFT,
+    ID_JUSTIFICATION_X_CENTER,
+    ID_JUSTIFICATION_X_RIGHT,
+
+    NUM_ID_JUSTIFICATION_X
+} ID_JUSTIFICATION_X;
+
+/* id_justification_x_sane_name returns SANE name for the width justification
+ * For unknown ID returns NULL
+ */
+const char* 
+id_justification_x_sane_name (ID_JUSTIFICATION_X id);
+
+/* id_justification_x_by_sane_name returns ID_JUSTIFICATION_X by its SANE name
+ */
+ID_JUSTIFICATION_X
+id_justification_x_by_sane_name (const char *name);
 
 /* ID_COLORMODE represents color mode
  */
@@ -2433,6 +2460,9 @@ enum {
     OPT_GAMMA,
     OPT_NEGATIVE,
 
+    /* Option specific to some ADF scans */
+    OPT_JUSTIFICATION_X,
+
     /* Total count of options, computed by compiler */
     NUM_OPTIONS
 };
@@ -2440,9 +2470,14 @@ enum {
 /* String constants for certain SANE options values
  * (missed from sane/sameopt.h)
  */
-#define OPTVAL_SOURCE_PLATEN      "Flatbed"
-#define OPTVAL_SOURCE_ADF_SIMPLEX "ADF"
-#define OPTVAL_SOURCE_ADF_DUPLEX  "ADF Duplex"
+#define OPTVAL_SOURCE_PLATEN        "Flatbed"
+#define OPTVAL_SOURCE_ADF_SIMPLEX   "ADF"
+#define OPTVAL_SOURCE_ADF_DUPLEX    "ADF Duplex"
+#define OPTVAL_JUSTIFICATION_X_LEFT   "Left"
+#define OPTVAL_JUSTIFICATION_X_CENTER "Center"
+#define OPTVAL_JUSTIFICATION_X_RIGHT  "Right"
+#define OPTVAL_JUSTIFICATION_X_NONE   "None"
+
 
 /* Check if option belongs to image enhancement group
  */
@@ -2513,6 +2548,7 @@ typedef struct {
     SANE_Range   res_range;              /* Resolutions range, in DPI */
     SANE_Range   win_x_range_mm;         /* Window x range, in mm */
     SANE_Range   win_y_range_mm;         /* Window y range, in mm */
+    
 } devcaps_source;
 
 /* Allocate devcaps_source
@@ -2552,6 +2588,10 @@ typedef struct {
 
     /* Sources */
     devcaps_source *src[NUM_ID_SOURCE];  /* Missed sources are NULL */
+
+    /* ADF X Justification */
+    unsigned int justification_x;  /*Current ADF width justification*/
+
 } devcaps;
 
 /* Initialize Device Capabilities
@@ -2595,6 +2635,7 @@ typedef struct {
     SANE_Fixed             highlight;         /* 0.0 ... +100.0 */
     SANE_Fixed             gamma;             /* Small positive value */
     bool                   negative;          /* Flip black and white */
+
 } devopt;
 
 /* Initialize device options


### PR DESCRIPTION
Some scanners specify a justification parameter for ADF scans. This
patch exposes the XJustification value as a read-only value.