### PR TITLE
Added Brother DCP-J552DW

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Legend:
 | ---------------------------------- | :-----------------------: | :-----------------------: |
 | Brother ADS-2700W                  | No                        | Yes                       |
 | Brother DCP-9020CDW                | No                        | Yes                       |
+| Brother DCP-J552DW                 | No                        | Yes                       |
 | Brother DCP-L2540DW                | No                        | Yes                       |
 | Brother DCP-L2550DN / DCP-L2550DW  | Yes                       |                           |
 | Brother HL-L2395DW series          | Yes                       |                           |


### PR DESCRIPTION
I have one at home, here's what `scanimage -L` says:
```
device `airscan:w0:Brother DCP-J552DW' is a WSD Brother DCP-J552DW 
```
The best part is it actually works! Thanks for this software :heart: