### PR TITLE
Add Brother HL-L2380DW series

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Legend:
 | Brother DCP-9020CDW                | No                        | Yes                       |
 | Brother DCP-L2540DW                | No                        | Yes                       |
 | Brother DCP-L2550DN / DCP-L2550DW  | Yes                       |                           |
+| Brother HL-L2380DW series          | No                        | Yes                       |
 | Brother HL-L2395DW series          | Yes                       |                           |
 | Brother MFC-J1300DW                | Yes                       |                           |
 | Brother MFC-J485DW                 | Yes                       |                           |


### PR DESCRIPTION
Running airscan-discover returns:
```
[devices]
  Brother HL-L2380DW series = http://[<ipv6>]:80/WebServices/ScannerService, WSD
  Brother HL-L2380DW series = http://<ipv4>:80/WebServices/ScannerService, WSD
  Brother HL-L2380DW series = http://[<ipv6>%254]:80/WebServices/ScannerService, WSD
```

Manually adding WSD and eSCL modes to /etc/sane.d/airscan.conf verifies that eSCL mode does not work and WSD mode works.  Leaving airscan.conf blank also works - WSD mode is automatically detected.