### PR TITLE
Porting to macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ common_CFLAGS 		+= -fPIC
 
 backend_LDFLAGS 	:= $(LDFLAGS)
 backend_LDFLAGS 	+= $(deps_LIBS) $(deps_LIBS_CODECS)
-backend_LDFLAGS 	+= -Wl,--version-script=airscan.sym -Wl,--no-undefined -lc
+backend_LDFLAGS 	+= -lc
 
 tools_LDFLAGS 		:= $(LDFLAGS)
 tools_LDFLAGS 		+= $(deps_LIBS)

--- a/airscan-os.c
+++ b/airscan-os.c
@@ -20,6 +20,8 @@
 #if defined(__OpenBSD__) || defined(__FreeBSD__)
 #   include <sys/types.h>
 #   include <sys/sysctl.h>
+#elif defined(__APPLE__)
+#   include <mach-o/dyld.h>
 #endif
 
 /* Static variables */
@@ -97,6 +99,13 @@ os_progname_init (void)
     const int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
     size_t    len = sizeof(os_progname_buf);
     int       rc = sysctl(mib, 4, os_progname_buf, &len, NULL, 0);
+
+    if (rc < 0) {
+        os_progname_buf[0] = '\0'; /* Just a paranoia */
+    }
+#elif defined(__APPLE__)
+    uint32_t  len = sizeof(os_progname_buf);
+    int       rc = _NSGetExecutablePath(os_progname_buf, &len);
 
     if (rc < 0) {
         os_progname_buf[0] = '\0'; /* Just a paranoia */

--- a/airscan-pollable.c
+++ b/airscan-pollable.c
@@ -34,6 +34,10 @@ pollable_new (void)
 {
 #ifdef OS_HAVE_EVENTFD
     int efd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+#elif __APPLE__
+    int fds[2];
+    int r = pipe(fds);
+    int efd = r < 0 ? r : fds[0];
 #else
     int fds[2];
     int r = pipe2(fds, O_CLOEXEC | O_NONBLOCK);

--- a/airscan.h
+++ b/airscan.h
@@ -28,6 +28,67 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#ifdef __APPLE__
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __BYTE_ORDER    BYTE_ORDER
+
+#endif /* __APPLE__ */
+
+#ifndef HAVE_MEMRCHR
+
+#include <sys/types.h>
+
+#ifndef SOCK_NONBLOCK
+#include <fcntl.h>
+# define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
+#ifndef SOCK_CLOEXEC
+#include <fcntl.h>
+# define SOCK_CLOEXEC O_CLOEXEC
+#endif
+
+
+/*
+ * Reverse memchr()
+ * Find the last occurrence of 'c' in the buffer 's' of size 'n'.
+ */
+static inline void *
+memrchr(const void *s, int c, size_t n)
+{
+    const unsigned char *cp;
+
+    if (n != 0) {
+       cp = (unsigned char *)s + n;
+       do {
+           if (*(--cp) == (unsigned char)c)
+               return (void *)cp;
+       } while (--n != 0);
+    }
+    return (void *)0;
+}
+#endif /* HAVE_MEMRCHR */
+
+
 #ifdef  __cplusplus
 extern "C" {
 #endif

--- a/test.c
+++ b/test.c
@@ -15,6 +15,9 @@
 
 SANE_Handle handle;
 
+extern int sigaction(int, const struct sigaction * __restrict,
+        struct sigaction * __restrict);
+
 void
 sigint_handler (int unused)
 {


### PR DESCRIPTION
This is preliminary work, following #239. It is currently only meant to share the changes I had to set in place, and is not yet using the `#if OS_HAVE_XXX` convention. This is planned once I can make a working build.

That being said, I was able to make it build on macOS, using :

- avahi, build from source using :

```
brew install libdeamon dbus

./configure --disable-qt5 --disable-gtk3 --disable-gdbm --disable-python --disable-monodoc --disable-pygobject CFLAGS=-D__APPLE_USE_RFC_3542 --disable-autoipd --prefix=(pwd)/build

make
make install
```

- sane-backends, installed by homebrew


The build command used is : 

```
PKG_CONFIG_PATH=/Users/syan/Downloads/IMPRIMANTE/avahi-0.8 \
C_INCLUDE_PATH=/opt/homebrew/Cellar/sane-backends/1.1.1/include:/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/arm/ \
LDFLAGS="-L/opt/homebrew/Cellar/sane-backends/1.1.1/lib -lsane -lxml2" \
CFLAGS='-D_XOPEN_SOURCE -D__APPLE_USE_RFC_3542' \
make
```

I have tried running the different test programs, but none of them seem to work yet : 

- `test` :

```
sane_init: calling
sane_init: done, status=Success
sane_open: calling
sane_open: done, status=Invalid argument
sane_open: Invalid argument
```

- `test-zeroconf`

```
=== testdata/test-zeroconf-1.cfg ===
can't open AF_ROUTE socket: Protocol not supported
fish: Job 1, './test-zeroconf' terminated by signal SIGSEGV (Address boundary error)
```

- `airscan-discover`

```
[devices]
```

I didn't do any setup yet, I might have missing something.

Since other porting works have been done on this library, someone may have next steps in mind I could work on to test further. On my end my next step is to read `sane-airscan.5.md` and try to set it up inside my current sane configuration, and see if it can see my scanner.