### PR TITLE
Fix Meson build - airscan-device.c:1520: undefined reference to 'image_format_detect'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ sources = [
   'airscan-filter.c',
   'airscan-http.c',
   'airscan-id.c',
+  'airscan-image.c',
   'airscan-inifile.c',
   'airscan-init.c',
   'airscan-ip.c',


### PR DESCRIPTION
Fix for:

```
/usr/bin/ld: /tmp/ccGyngZO.ltrans2.ltrans.o: in function `sane_read':
sane-airscan-d9f2fd670dcb81c03fea7087fb9b47cdbe680fd5/redhat-linux-build/../airscan-device.c:1520: undefined reference to `image_format_detect'
```

Btw, any chance for a new releases? The last one is from 2021. Even if the master branch does not contain anything significant, releases are cheap.

Thanks,
--Simone