### PR TITLE
Add Xerox WorkCentre 6515

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Legend:
 | Xerox VersaLink B405               | Yes                       |                           |
 | Xerox WorkCentre 3025              | No                        | Yes                       |
 | Xerox WorkCentre 6027              | No                        | Yes<sup>[10](#note10)</sup>|
-| Xerox WorkCentre 6515              | n                         | Yes                       |
+| Xerox WorkCentre 6515              |                           | Yes                       |
 | TODO                               |                           |                           |
 
 ---

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Legend:
 | Xerox VersaLink B405               | Yes                       |                           |
 | Xerox WorkCentre 3025              | No                        | Yes                       |
 | Xerox WorkCentre 6027              | No                        | Yes<sup>[10](#note10)</sup>|
+| Xerox WorkCentre 6515              | n                         | Yes                       |
 | TODO                               |                           |                           |
 
 ---


### PR DESCRIPTION
I tested scanning with my Xerox WorkCentre 6515 using WSD mode and it worked like a charm. Thus, adding this info to the table. I didn't test AirPrint since I disabled it on my device.
I also can no longer remember if WSD was disabled by default, so I didn't copy the footnote from the Xerox WorkCentre 6027.