### PR TITLE
Add HP Color Laser MFP M178nw

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Legend:
 | HP ENVY Photo 6200 series          | Yes                       |                           |
 | HP ENVY Photo 7800 series          | Yes                       |                           |
 | HP ENVY Pro 6400 series            | Yes                       |                           |
+| HP Color Laser MFP M178nw          | Yes                       |                           |
 | HP LaserJet 200 colorMFP M276n     | No                        | Yes                       |
 | HP LaserJet MFP E62655             | Yes                       |                           |
 | HP LaserJet MFP M130fw             | No                        | Yes                       |


### PR DESCRIPTION
Add HP Color Laser MFP M178nw - verified to be working as eSCL device on Fedora 39.