### PR TITLE
docs: add Brother MFC-L3780CDW

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Legend:
 | Brother MFC-L2720DW                | No                        | Yes                       |
 | Brother MFC-L2750DW                | Yes                       | Yes                       |
 | Brother MFC-L3750CDW               | No                        | Yes                       |
+| Brother MFC-L3780CDW               | No                        | Yes                       |
 | Brother MFC-T910DW                 | Yes                       | Yes                       |
 | Canon D570                         | Yes                       |                           |
 | Canon G600 series                  | Yes                       |                           |


### PR DESCRIPTION
At the very least simple scans work fine.

```
>airscan-discover
[devices]
  Brother MFC-L3780CDW series = http://10.9.8.245:80/WebServices/ScannerService, WSD
```