### PR TITLE
Address ImagesToTransfer behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ Legend:
 | Lexmark MC2535adwe                 | Yes                       |                           |
 | Lexmark MC3224adwe                 | Yes                       |                           |
 | Lexmark MC3326adwe                 | Yes                       |                           |
+| OKI-MB471                          |                           | Yes                       |
+| OKI-MC332dn                        |                           | Yes                       |
+| OKI-MC362dn                        |                           | Yes                       |
 | OKI-MC853                          | Yes                       |                           |
-| OKI-MB471                          | Yes                       |                           |
-| OKI-MC332                          | Yes                       |                           |
 | Panasonic KV-S1058Y                | No                        | Yes                       |
 | Pantum BM5100ADW series            | Yes                       | Yes                       |
 | Pantum M6500W series               | Yes                       |                           |

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Legend:
 | Lexmark MC3224adwe                 | Yes                       |                           |
 | Lexmark MC3326adwe                 | Yes                       |                           |
 | OKI-MC853                          | Yes                       |                           |
+| OKI-MB471                          | Yes                       |                           |
+| OKI-MC332                          | Yes                       |                           |
 | Panasonic KV-S1058Y                | No                        | Yes                       |
 | Pantum BM5100ADW series            | Yes                       | Yes                       |
 | Pantum M6500W series               | Yes                       |                           |


### PR DESCRIPTION
Some devices don't behave if sca:ImagesToTransfer isn't set as expected.
Behaviour according to specification:

- single image to scan, ImagesToTransfer = 1 as for Flatbed
- multiple or unknown amount of images to scan, ImagesToTransfer = 0 as for ADF

Known devices affected:

- OKI MC332dn
- OKI MC362dn
- OKI MB471

Only relevant for WSD.