### PR TITLE
Add scan intent / WSD content type selection

### DIFF
--- a/airscan-device.c
+++ b/airscan-device.c
@@ -1040,6 +1040,7 @@ device_stm_start_scan (device *dev)
     params->y_res = y_resolution;
     params->src = dev->opt.src;
     params->colormode = dev->opt.colormode_real;
+    params->scanintent = dev->opt.scanintent;
     params->format = device_choose_format(dev, src);
 
     /* Dump parameters */
@@ -1051,6 +1052,8 @@ device_stm_start_scan (device *dev)
             id_colormode_sane_name(dev->opt.colormode_emul));
     log_trace(dev->log, "  colormode_real: %s",
             id_colormode_sane_name(params->colormode));
+    log_trace(dev->log, "  scanintent: %s",
+            id_scanintent_sane_name(params->scanintent));
     log_trace(dev->log, "  tl_x:           %s mm",
             math_fmt_mm(dev->opt.tl_x, buf));
     log_trace(dev->log, "  tl_y:           %s mm",

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -341,6 +341,39 @@ escl_devcaps_source_parse_setting_profiles (xml_rd *xml, devcaps_source *src)
     return err;
 }
 
+/* Parse supported intents (photo/document etc).
+ */
+static error
+escl_devcaps_source_parse_supported_intents (xml_rd *xml, devcaps_source *src)
+{
+    error err = NULL;
+
+    xml_rd_enter(xml);
+    for (; !xml_rd_end(xml); xml_rd_next(xml)) {
+        if(xml_rd_node_name_match(xml, "scan:Intent")) {
+            const char *v = xml_rd_node_value(xml);
+            if (!strcmp(v, "Document")) {
+                src->scanintents |= 1 << ID_SCANINTENT_DOCUMENT;
+            } else if (!strcmp(v, "TextAndGraphic")) {
+                src->scanintents |= 1 << ID_SCANINTENT_TEXTANDGRAPHIC;
+            } else if (!strcmp(v, "Photo")) {
+                src->scanintents |= 1 << ID_SCANINTENT_PHOTO;
+            } else if (!strcmp(v, "Preview")) {
+                src->scanintents |= 1 << ID_SCANINTENT_PREVIEW;
+            } else if (!strcmp(v, "Object")) {
+                src->scanintents |= 1 << ID_SCANINTENT_OBJECT;
+            } else if (!strcmp(v, "BusinessCard")) {
+                src->scanintents |= 1 << ID_SCANINTENT_BUSINESSCARD;
+            } else {
+                log_debug(NULL, "unknown intent: %s", v);
+            }
+        }
+    }
+    xml_rd_leave(xml);
+
+    return err;
+}
+
 
 /* Parse ADF justification
  */
@@ -396,6 +429,8 @@ escl_devcaps_source_parse (xml_rd *xml, devcaps_source **out)
             err = xml_rd_node_value_uint(xml, &src->max_hei_px);
         } else if (xml_rd_node_name_match(xml, "scan:SettingProfiles")) {
             err = escl_devcaps_source_parse_setting_profiles(xml, src);
+        } else if (xml_rd_node_name_match(xml, "scan:SupportedIntents")) {
+            err = escl_devcaps_source_parse_supported_intents(xml, src);
         }
     }
     xml_rd_leave(xml);
@@ -732,6 +767,7 @@ escl_scan_query (const proto_ctx *ctx)
     const proto_scan_params *params = &ctx->params;
     const char              *source = NULL;
     const char              *colormode = NULL;
+    const char              *scanintent = NULL;
     const char              *mime = id_format_mime_name(ctx->params.format);
     const devcaps_source    *src = ctx->devcaps->src[params->src];
     bool                    duplex = false;
@@ -756,10 +792,27 @@ escl_scan_query (const proto_ctx *ctx)
         log_internal_error(ctx->log);
     }
 
+    switch (params->scanintent) {
+    case ID_SCANINTENT_DOCUMENT:       scanintent = "Document"; break;
+    case ID_SCANINTENT_TEXTANDGRAPHIC: scanintent = "TextAndGraphic"; break;
+    case ID_SCANINTENT_PHOTO:          scanintent = "Photo"; break;
+    case ID_SCANINTENT_PREVIEW:        scanintent = "Preview"; break;
+    case ID_SCANINTENT_OBJECT:         scanintent = "Object"; break;
+    case ID_SCANINTENT_BUSINESSCARD:   scanintent = "BusinessCard"; break;
+    case ID_SCANINTENT_UNKNOWN: break;
+
+    default:
+        log_internal_error(ctx->log);
+    }
+
     /* Build scan request */
     xml_wr *xml = xml_wr_begin("scan:ScanSettings", escl_xml_wr_ns);
 
     xml_wr_add_text(xml, "pwg:Version", "2.0");
+
+    if (scanintent) {
+        xml_wr_add_text(xml, "scan:Intent", scanintent);
+    }
 
     xml_wr_enter(xml, "pwg:ScanRegions");
     xml_wr_enter(xml, "pwg:ScanRegion");

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -177,6 +177,40 @@ id_format_short_name (ID_FORMAT id)
     return name ? name : mime;
 }
 
+/******************** ID_SCANINTENT ********************/
+/* id_scanintent_sane_name_table represents ID_SCANINTENT to
+ * SANE name mapping
+ */
+static id_name_table id_scanintent_sane_name_table[] = {
+    {ID_SCANINTENT_AUTO,           "Auto"},
+    {ID_SCANINTENT_DOCUMENT,       "Text"},
+    {ID_SCANINTENT_TEXTANDGRAPHIC, "Text and Graphic"},
+    {ID_SCANINTENT_PHOTO,          "Photo"},
+    {ID_SCANINTENT_PREVIEW,        "Preview"},
+    {ID_SCANINTENT_OBJECT,         "3D Object"},
+    {ID_SCANINTENT_BUSINESSCARD,   "Business Card"},
+    {ID_SCANINTENT_HALFTONE,       "Halftone"},
+    {-1, NULL}
+};
+
+/* id_scanintent_sane_name returns SANE name for the scan intent
+ * For unknown ID returns NULL
+ */
+const char*
+id_scanintent_sane_name (ID_SCANINTENT id)
+{
+    return id_name(id, id_scanintent_sane_name_table);
+}
+
+/* id_scanintent_by_sane_name returns ID_SCANINTENT by its SANE name
+ * For unknown name returns ID_SCANINTENT_UNKNOWN
+ */
+ID_SCANINTENT
+id_scanintent_by_sane_name (const char *name)
+{
+    return id_by_name(name, strcasecmp, id_scanintent_sane_name_table);
+}
+
 
 /******************** ID_JUSTIFICATION ********************/
 /* id_justification_sane_name_table represents ID_JUSTIFICATION to

--- a/airscan.h
+++ b/airscan.h
@@ -794,6 +794,34 @@ id_format_by_mime_name (const char *name);
 const char*
 id_format_short_name (ID_FORMAT id);
 
+/* ID_SCANINTENT represents scan intent
+ */
+typedef enum {
+    ID_SCANINTENT_UNKNOWN = -1,
+    ID_SCANINTENT_AUTO, /* maps to WSD ContentType=Auto */
+    ID_SCANINTENT_DOCUMENT, /* text */
+    ID_SCANINTENT_TEXTANDGRAPHIC, /* mixed */
+    ID_SCANINTENT_PHOTO,
+    ID_SCANINTENT_PREVIEW,
+    ID_SCANINTENT_OBJECT, /* 3D objects */
+    ID_SCANINTENT_BUSINESSCARD,
+    ID_SCANINTENT_HALFTONE, /* maps to WSD ContentType=Halftone */
+
+    NUM_ID_SCANINTENT
+} ID_SCANINTENT;
+
+/* id_scanintent_sane_name returns SANE name for the scan intents
+ * For unknown ID returns NULL
+ */
+const char*
+id_scanintent_sane_name (ID_SCANINTENT id);
+
+/* id_scanintent_by_sane_name returns ID_SCANINTENT by its SANE name
+ * For unknown name returns ID_SCANINTENT_UNKNOWN
+ */
+ID_SCANINTENT
+id_scanintent_by_sane_name (const char *name);
+
 /******************** Device ID ********************/
 /* Allocate unique device ID
  */
@@ -2535,6 +2563,7 @@ enum {
     OPT_GROUP_STANDARD,
     OPT_SCAN_RESOLUTION,
     OPT_SCAN_COLORMODE,         /* I.e. color/grayscale etc */
+    OPT_SCAN_INTENT,            /* Document/Photo etc */
     OPT_SCAN_SOURCE,            /* Platem/ADF/ADF Duplex */
 
     /* Geometry options group */
@@ -2648,6 +2677,7 @@ typedef struct {
     unsigned int flags;                  /* Source flags */
     unsigned int colormodes;             /* Set of 1 << ID_COLORMODE */
     unsigned int formats;                /* Set of 1 << ID_FORMAT */
+    unsigned int scanintents;            /* Set of 1 << ID_SCANINTENT */
     SANE_Word    min_wid_px, max_wid_px; /* Min/max width, in pixels */
     SANE_Word    min_hei_px, max_hei_px; /* Min/max height, in pixels */
     SANE_Word    *resolutions;           /* Discrete resolutions, in DPI */
@@ -2732,12 +2762,14 @@ typedef struct {
     ID_SOURCE              src;               /* Current source */
     ID_COLORMODE           colormode_emul;    /* Current "emulated" color mode*/
     ID_COLORMODE           colormode_real;    /* Current real color mode*/
+    ID_SCANINTENT          scanintent;        /* Current scan intent */
     SANE_Word              resolution;        /* Current resolution */
     SANE_Fixed             tl_x, tl_y;        /* Top-left x/y */
     SANE_Fixed             br_x, br_y;        /* Bottom-right x/y */
     SANE_Parameters        params;            /* Scan parameters */
     SANE_String            *sane_sources;     /* Sources, in SANE format */
     SANE_String            *sane_colormodes;  /* Color modes in SANE format */
+    SANE_String            *sane_scanintents; /* Scan intents in SANE format */
     SANE_Fixed             brightness;        /* -100.0 ... +100.0 */
     SANE_Fixed             contrast;          /* -100.0 ... +100.0 */
     SANE_Fixed             shadow;            /* 0.0 ... +100.0 */
@@ -3240,6 +3272,7 @@ typedef struct {
     int           x_res, y_res; /* X/Y resolution */
     ID_SOURCE     src;          /* Desired source */
     ID_COLORMODE  colormode;    /* Desired color mode */
+    ID_SCANINTENT scanintent;   /* Desired scan intent */
     ID_FORMAT     format;       /* Desired image format */
 } proto_scan_params;
 


### PR DESCRIPTION
**WSD: Add content type selection**

Handle the WSD device settings element `ContentTypesSupported`, present its values as an option, and pass the selection to the scan job as `ContentType`.

The actual identifiers in code are made to match eSCL's "scan intent" setting, except for content type values exclusive to WSD. The setting is presented as `airscan-scan-intent`.

On some devices, this setting affects how colour is processed, and the default mode when not specified can result in inaccurate colours.

**eSCL: Add scan intent selection**

---

I reference this option from https://learn.microsoft.com/en-us/windows-hardware/drivers/image/contenttypevalue and https://learn.microsoft.com/en-us/windows-hardware/drivers/image/contenttype . The Canon PIXMA TR4570 I tested with supports "Text" and "Photo". Without setting the ContentType parameter, it seems to default to "Text".

<details>
<summary>Example scans</summary>

This is a cropped scan of a Mario Kart 8 Deluxe game cover, scanned right from the box with the plastic cover on.

Text: Highlights appears to be oversaturated and shadows are missing details.
![scan_text](https://github.com/user-attachments/assets/63481113-db32-4a91-9898-7245067d4a3b)

Photo:
![scan_photo](https://github.com/user-attachments/assets/50fb1f53-97ea-4b47-8d1d-7623741e4bd9)
</details>

I hacked this together in half an afternoon, so I don't expect this to be mergeable as-is. This PR completely neglected eSCL as the TR4570 doesn't seem to support eSCL so I have no way to test it.