### PR TITLE
Merge scan-intent parameter support into the main branch

### DIFF
--- a/airscan-devcaps.c
+++ b/airscan-devcaps.c
@@ -253,6 +253,19 @@ devcaps_dump (log_ctx *log, devcaps *caps, bool trace)
         }
 
         log_func(log, "    Formats:     %s", buf);
+
+        str_trunc(buf);
+
+        for (i = 0; i < NUM_ID_SCANINTENT; i ++) {
+            if ((src->scanintents & (1 << i)) != 0) {
+                if (buf[0] != '\0') {
+                    buf = str_append(buf, ", ");
+                }
+                buf = str_append(buf, id_scanintent_sane_name(i));
+            }
+        }
+
+        log_func(log, "    Intents:     %s", buf);
     }
 
     mem_free(buf);

--- a/airscan-device.c
+++ b/airscan-device.c
@@ -1052,7 +1052,7 @@ device_stm_start_scan (device *dev)
             id_colormode_sane_name(dev->opt.colormode_emul));
     log_trace(dev->log, "  colormode_real: %s",
             id_colormode_sane_name(params->colormode));
-    log_trace(dev->log, "  scanintent: %s",
+    log_trace(dev->log, "  scanintent:     %s",
             id_scanintent_sane_name(params->scanintent));
     log_trace(dev->log, "  tl_x:           %s mm",
             math_fmt_mm(dev->opt.tl_x, buf));

--- a/airscan-devops.c
+++ b/airscan-devops.c
@@ -283,7 +283,7 @@ devopt_rebuild_opt_desc (devopt *opt)
     desc = &opt->desc[OPT_SCAN_INTENT];
     desc->name = "scan-intent";
     desc->title = "Scan intent";
-    desc->desc = "Selects the scan intent.";
+    desc->desc = "Optimize scan for Text/Photo/etc.";
     desc->type = SANE_TYPE_STRING;
     desc->size = sane_string_array_max_strlen(opt->sane_scanintents) + 1;
     desc->cap = SANE_CAP_SOFT_SELECT | SANE_CAP_SOFT_DETECT;

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -793,13 +793,13 @@ escl_scan_query (const proto_ctx *ctx)
     }
 
     switch (params->scanintent) {
+    case ID_SCANINTENT_UNSET:          break;
     case ID_SCANINTENT_DOCUMENT:       scanintent = "Document"; break;
     case ID_SCANINTENT_TEXTANDGRAPHIC: scanintent = "TextAndGraphic"; break;
     case ID_SCANINTENT_PHOTO:          scanintent = "Photo"; break;
     case ID_SCANINTENT_PREVIEW:        scanintent = "Preview"; break;
     case ID_SCANINTENT_OBJECT:         scanintent = "Object"; break;
     case ID_SCANINTENT_BUSINESSCARD:   scanintent = "BusinessCard"; break;
-    case ID_SCANINTENT_UNKNOWN: break;
 
     default:
         log_internal_error(ctx->log);

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -350,7 +350,7 @@ escl_devcaps_source_parse_supported_intents (xml_rd *xml, devcaps_source *src)
 
     xml_rd_enter(xml);
     for (; !xml_rd_end(xml); xml_rd_next(xml)) {
-        if(xml_rd_node_name_match(xml, "scan:Intent")) {
+        if(xml_rd_node_name_match(xml, "scan:SupportedIntent")) {
             const char *v = xml_rd_node_value(xml);
             if (!strcmp(v, "Document")) {
                 src->scanintents |= 1 << ID_SCANINTENT_DOCUMENT;

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -182,6 +182,7 @@ id_format_short_name (ID_FORMAT id)
  * SANE name mapping
  */
 static id_name_table id_scanintent_sane_name_table[] = {
+    {ID_SCANINTENT_UNSET,          "*unset*"},
     {ID_SCANINTENT_AUTO,           "Auto"},
     {ID_SCANINTENT_DOCUMENT,       "Document"},
     {ID_SCANINTENT_TEXTANDGRAPHIC, "Text and Graphic"},

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -183,7 +183,7 @@ id_format_short_name (ID_FORMAT id)
  */
 static id_name_table id_scanintent_sane_name_table[] = {
     {ID_SCANINTENT_AUTO,           "Auto"},
-    {ID_SCANINTENT_DOCUMENT,       "Text"},
+    {ID_SCANINTENT_DOCUMENT,       "Document"},
     {ID_SCANINTENT_TEXTANDGRAPHIC, "Text and Graphic"},
     {ID_SCANINTENT_PHOTO,          "Photo"},
     {ID_SCANINTENT_PREVIEW,        "Preview"},

--- a/airscan-wsd.c
+++ b/airscan-wsd.c
@@ -826,12 +826,12 @@ wsd_scan_query (const proto_ctx *ctx)
     }
 
     switch (params->scanintent) {
+    case ID_SCANINTENT_UNSET:          break;
     case ID_SCANINTENT_AUTO:           contenttype = "Auto"; break;
     case ID_SCANINTENT_DOCUMENT:       contenttype = "Text"; break;
     case ID_SCANINTENT_PHOTO:          contenttype = "Photo"; break;
     case ID_SCANINTENT_HALFTONE:       contenttype = "Halftone"; break;
     case ID_SCANINTENT_TEXTANDGRAPHIC: contenttype = "Mixed"; break;
-    case ID_SCANINTENT_UNKNOWN: break;
 
     default:
         log_internal_error(ctx->log);

--- a/airscan.h
+++ b/airscan.h
@@ -811,6 +811,7 @@ id_format_short_name (ID_FORMAT id);
  */
 typedef enum {
     ID_SCANINTENT_UNKNOWN = -1,
+    ID_SCANINTENT_UNSET,          /* Intent is not set */
     ID_SCANINTENT_AUTO,           /*                        WSD: Auto */
     ID_SCANINTENT_DOCUMENT,       /* eSCL: Docoment,        WSD: Text */
     ID_SCANINTENT_TEXTANDGRAPHIC, /* eSCL: TextAndGraphic,  WSD: Mixed */

--- a/airscan.h
+++ b/airscan.h
@@ -795,17 +795,30 @@ const char*
 id_format_short_name (ID_FORMAT id);
 
 /* ID_SCANINTENT represents scan intent
+ *
+ * Intent hints scanner on a purpose of requested scan, which may
+ * imply carious parameters tweaks depending on that purpose.
+ *
+ * Intent maps to the eSCL Intent (see Mopria eSCL Technical Specification, 5)
+ * and WSD ContentType. The semantics of these two parameters looks very
+ * similar.
+ *
+ * Please note, eSCL defines also the ContentType parameter, but after
+ * some thinking and discussion we came to conclusion that Intent better
+ * maps our need.
+ *
+ * Dee discussion at: https://github.com/alexpevzner/sane-airscan/pull/351
  */
 typedef enum {
     ID_SCANINTENT_UNKNOWN = -1,
-    ID_SCANINTENT_AUTO, /* maps to WSD ContentType=Auto */
-    ID_SCANINTENT_DOCUMENT, /* text */
-    ID_SCANINTENT_TEXTANDGRAPHIC, /* mixed */
-    ID_SCANINTENT_PHOTO,
-    ID_SCANINTENT_PREVIEW,
-    ID_SCANINTENT_OBJECT, /* 3D objects */
-    ID_SCANINTENT_BUSINESSCARD,
-    ID_SCANINTENT_HALFTONE, /* maps to WSD ContentType=Halftone */
+    ID_SCANINTENT_AUTO,           /*                        WSD: Auto */
+    ID_SCANINTENT_DOCUMENT,       /* eSCL: Docoment,        WSD: Text */
+    ID_SCANINTENT_TEXTANDGRAPHIC, /* eSCL: TextAndGraphic,  WSD: Mixed */
+    ID_SCANINTENT_PHOTO,          /* eSCL: Photo,           WSD: Photo */
+    ID_SCANINTENT_PREVIEW,        /* eSCL: Preview */
+    ID_SCANINTENT_OBJECT,         /* eSCL: Objects (3d scan) */
+    ID_SCANINTENT_BUSINESSCARD,   /* eSCL: BusinessCard */
+    ID_SCANINTENT_HALFTONE,       /*                        WSD: Halftone */
 
     NUM_ID_SCANINTENT
 } ID_SCANINTENT;


### PR DESCRIPTION
Both eSCL and WSD contains a very similar parameter, called `Intent` in the **eSCL** and `ContentType` in the **WSD**, which hints the scanner on the purpose of the scan request, letting scanner to choose optimal scan parameters.

`Intent` is documented in the Mopria eSCL Scan Specification, chapter 5 (https://mopria.org/mopria-escl-specification).

`ContentType` is documented by Microsoft here (https://learn.microsoft.com/en-us/windows-hardware/drivers/image/contenttypevalue) and here (https://learn.microsoft.com/en-us/windows-hardware/drivers/image/contenttype).

This patch (mostly contributed by @alvinhochun and polished by me), brings the uniform, protocol-independent access to this parameter into the set of scanner options, supported by `sane-airscan`