### PR TITLE
docs: Add Brother ADS-4300N

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Legend:
 | Device                             | eSCL mode                 | WSD mode                  |
 | ---------------------------------- | :-----------------------: | :-----------------------: |
 | Brother ADS-2700W                  | No                        | Yes                       |
+| Brother ADS-4300N                  | Yes                       | Yes                       |
 | Brother DCP-7055W                  | No                        | Yes                       |
 | Brother DCP-7070DW                 | No                        | Yes                       |
 | Brother DCP-9020CDW                | No                        | Yes                       |


### PR DESCRIPTION
Tested Brother ADS-4300N scanner on Arch Linux, connected over network and over USB via ipp-usb. Multi-page documents and double-sided scanning works as expected over both network and USB.

```
# Over network:
$ airscan-discover
airscan-discover 
[devices]
  Brother ADS-4300N [000EC69484E2] = http://[fe80::20e:c6ff:fe94:84e2%252]:8080/eSCL/, eSCL
  Brother ADS-4300N [000EC69484E2] = https://[fe80::20e:c6ff:fe94:84e2%252]:443/eSCL/, eSCL
  Brother ADS-4300N [000EC69484E2] = http://192.168.1.27:8080/eSCL/, eSCL
  Brother ADS-4300N [000EC69484E2] = https://192.168.1.27:443/eSCL/, eSCL
  Brother ADS-4300N [000EC69484E2] = http://[fe80::20e:c6ff:fe94:84e2%252]:53048, WSD
  Brother ADS-4300N [000EC69484E2] = http://192.168.1.27:53048, WSD
```
```
# Over USB, with ipp-usb:
$ airscan-discover
[devices]
  Brother ADS-4300N (USB) = http://[::1]:60000/eSCL/, eSCL
  Brother ADS-4300N (USB) = http://127.0.0.1:60000/eSCL/, eSCL
```

Thank you for making sane-airscan! At least for my purposes, sane-airscan works well and the official Brother drivers are totally unnecessary.