### PR TITLE
Added the "pretend-local" config option for networked scanners to be treated as if attached locally

### DIFF
--- a/airscan-conf.c
+++ b/airscan-conf.c
@@ -295,6 +295,8 @@ conf_load_from_ini (inifile *ini)
                     if (conf.socket_dir == NULL) {
                         conf_perror(rec, "failed to expand socket_dir path");
                     }
+                } else if (inifile_match_name(rec->variable, "pretend-local")) {
+                    conf_load_bool(rec, &conf.pretend_local, "true", "false");
                 }
             } else if (inifile_match_name(rec->section, "debug")) {
                 if (inifile_match_name(rec->variable, "trace")) {

--- a/airscan.c
+++ b/airscan.c
@@ -57,7 +57,7 @@ sane_get_devices (const SANE_Device ***device_list, SANE_Bool local_only)
 {
     log_debug(NULL, "API: sane_get_devices(): called");
 
-    if (local_only) {
+    if (local_only && !conf.pretend_local) {
         /* Note, all our devices are non-local */
         static const SANE_Device *empty_devlist[1] = {0};
         *device_list = empty_devlist;

--- a/airscan.conf
+++ b/airscan.conf
@@ -39,6 +39,19 @@
 # can be found.  If an eSCL device's URL is in the form unix://socket/eSCL/,
 # traffic will be sent through socket_dir/socket instead of TCP.  If not
 # specified, sockets will be searched for in /var/run.
+#
+# Proxy mode
+#   pretend-local = false ; Remote scanners are marked as such (DEFAULT)
+#   pretend-local = true  ; Remote scanners are treated as if they were local
+#
+# The SANE network protocol destinguishes between locally attached devices,
+# and devices that can only be accessed over the network. While this is
+# useful information to have, it isn't always used consistently. In particular,
+# the saned daemon refuses to make any scanners available that aren't local
+# to the machine. While well-intentioned, there are use-cases where this is
+# unexpected; for instance in proxies that translate from eSCL/WSD protocols
+# to the SANE protocol. Setting this configuration options instructs
+# sane-airscan to treat all eSCL/WSD devices as if they were attached locally.
 
 [options]
 #discovery = enable
@@ -46,6 +59,7 @@
 #protocol = auto
 #ws-discovery = fast
 #socket_dir = /var/run
+#pretend-local = false
 
 # Configuration of debug facilities
 #   trace = path         ; enables protocol trace and configures output

--- a/airscan.h
+++ b/airscan.h
@@ -1391,6 +1391,7 @@ typedef struct {
     WSDD_MODE      wsdd_mode;        /* WS-Discovery mode */
     const char     *socket_dir;      /* Directory for AF_UNIX sockets */
     conf_blacklist *blacklist;       /* Devices blacklisted for discovery */
+    bool           pretend_local;    /* Pretend devices are local */
 } conf_data;
 
 #define CONF_INIT {                     \
@@ -1402,7 +1403,8 @@ typedef struct {
         .model_is_netname = true,       \
         .proto_auto = true,             \
         .wsdd_mode = WSDD_FAST,         \
-        .socket_dir = NULL              \
+        .socket_dir = NULL,             \
+        .pretend_local = false          \
     }
 
 extern conf_data conf;

--- a/sane-airscan.5
+++ b/sane-airscan.5
@@ -63,6 +63,8 @@ To figure out URLs of available devices, the simplest way is to run the supplied
 If running \fBairscan\-discover(1)\fR on the same LAN segment as a scanner is not possible, you will have to follow a hard way\. Your administrator must know device IP address, consult your device manual for the eSCL port, and the URL path component most likely is the "/eSCL", though on some devices it may differ\. Discovering WSD URLs doing this way is much harder, because it is very difficult to guess TCP port and URL path, that in a case of eSCL\.
 .P
 For eSCL devices, the URL can also use the unix:// scheme, such as unix://scanner\.sock/eSCL\. The "host" from the URL is a file name that will be searched for in the directory specified by socket_dir (see below)\. When connecting to the scanner, all traffic will be sent to the specified UNIX socket instead of a TCP connection\.
+.P
+By default, sane\-airscan treats all scanners as remote devices. This can be undesirable, if configuring a proxy that translates from eSCL/WSD to the SANE protocol, as \fBsaned(8)\fR ignores any device that isn't attached locally. By setting \fBpretend\-local = true\fR, sane-airscan can make its devices accessible to the SANE network daemon.
 .SH "CONFIGURATION OPTIONS"
 Miscellaneous options all goes to the \fB[options]\fR section\. Currently the following options are supported:
 .IP "" 4
@@ -94,6 +96,12 @@ ws\-discovery = fast | full | off
 ; socket name (not a full path)\.  The name will be searched for in the
 ; directory specified here\. The default is /var/run\.
 socket_dir = /path/to/directory
+
+; Configure whether eSCL and WSD devices should be treated as if
+; they were attached locally. The default behavior considers them as
+; remote devices that are accessed over the network. This option has
+; to be changed when exporting a scanner through "saned".
+pretend\-local = false | true
 .fi
 .IP "" 0
 .SH "BLACKLISTING DEVICES"

--- a/sane-airscan.5
+++ b/sane-airscan.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SANE\-AIRSCAN" "5" "May 2022" "" "AirScan (eSCL) and WSD SANE backend"
+.TH "SANE\-AIRSCAN" "5" "January 2025" "" "AirScan (eSCL) and WSD SANE backend"
 .SH "NAME"
 \fBsane\-airscan\fR \- SANE backend for AirScan (eSCL) and WSD scanners and MFP
 .SH "DESCRIPTION"
@@ -64,7 +64,7 @@ If running \fBairscan\-discover(1)\fR on the same LAN segment as a scanner is no
 .P
 For eSCL devices, the URL can also use the unix:// scheme, such as unix://scanner\.sock/eSCL\. The "host" from the URL is a file name that will be searched for in the directory specified by socket_dir (see below)\. When connecting to the scanner, all traffic will be sent to the specified UNIX socket instead of a TCP connection\.
 .P
-By default, sane\-airscan treats all scanners as remote devices. This can be undesirable, if configuring a proxy that translates from eSCL/WSD to the SANE protocol, as \fBsaned(8)\fR ignores any device that isn't attached locally. By setting \fBpretend\-local = true\fR, sane-airscan can make its devices accessible to the SANE network daemon.
+By default, sane\-airscan treats all scanners as remote devices\. This can be undesirable, if configuring a proxy that translates from eSCL/WSD to the SANE protocol, as \fBsaned(8)\fR ignores any device that isn't attached locally\. By setting \fBpretend\-local = true\fR, sane\-airscan can make its devices accessible to the SANE network daemon\.
 .SH "CONFIGURATION OPTIONS"
 Miscellaneous options all goes to the \fB[options]\fR section\. Currently the following options are supported:
 .IP "" 4
@@ -98,9 +98,9 @@ ws\-discovery = fast | full | off
 socket_dir = /path/to/directory
 
 ; Configure whether eSCL and WSD devices should be treated as if
-; they were attached locally. The default behavior considers them as
-; remote devices that are accessed over the network. This option has
-; to be changed when exporting a scanner through "saned".
+; they were attached locally\. The default behavior considers them as
+; remote devices that are accessed over the network\. This option has
+; to be changed when exporting a scanner through "saned"\.
 pretend\-local = false | true
 .fi
 .IP "" 0
@@ -116,9 +116,9 @@ ip    = 192\.168\.0\.0/24 ; blacklist the whole subnet
 .fi
 .IP "" 0
 .P
-Network names come from DNS\-SD, WS\-Discovery doesn\'t provide this information\. For filtering by network name to work, Avahi must be enabled and device must be discoverable via DNS\-SD (not necessarily as a scanner, it\'s enough if WSD scanner is discoverable as a printer via DNS\-SD)\.
+Network names come from DNS\-SD, WS\-Discovery doesn't provide this information\. For filtering by network name to work, Avahi must be enabled and device must be discoverable via DNS\-SD (not necessarily as a scanner, it's enough if WSD scanner is discoverable as a printer via DNS\-SD)\.
 .P
-Blacklisting only affects automatic discovery, and doesn\'t affect manually configured devices\.
+Blacklisting only affects automatic discovery, and doesn't affect manually configured devices\.
 .SH "DEBUGGING"
 sane\-airscan provides very good instrumentation for troubleshooting without physical access to the problemmatic device\.
 .P

--- a/sane-airscan.5.md
+++ b/sane-airscan.5.md
@@ -80,6 +80,12 @@ searched for in the directory specified by socket_dir (see below).  When
 connecting to the scanner, all traffic will be sent to the specified UNIX socket
 instead of a TCP connection.
 
+By default, sane-airscan treats all scanners as remote devices. This can be
+undesirable, if configuring a proxy that translates from eSCL/WSD to the SANE
+protocol, as `saned(8)` ignores any device that isn't attached locally. By
+setting `pretend-local = true`, sane-airscan can make its devices accessible
+to the SANE network daemon.
+
 ## CONFIGURATION OPTIONS
 
 Miscellaneous options all goes to the ``[options]`` section. Currently
@@ -112,6 +118,12 @@ the following options are supported:
     ; socket name (not a full path).  The name will be searched for in the
     ; directory specified here. The default is /var/run.
     socket_dir = /path/to/directory
+
+    ; Configure whether eSCL and WSD devices should be treated as if
+    ; they were attached locally. The default behavior considers them as
+    ; remote devices that are accessed over the network. This option has
+    ; to be changed when exporting a scanner through "saned".
+    pretend-local = false | true
 
 ## BLACKLISTING DEVICES
 


### PR DESCRIPTION
Scanners discovered by sane-airscan cannot be exported by saned, as the latter only operates on locally attached devices. This prevents some entirely reasonable use cases, as it is a bit ambiguous what locality even means in the context of scanners that only have an eSCL/WSD interface. The new "pretend-local" configuration option allows an administrator to set a policy that overrides the default behavior and makes these devices compatible with the SANE daemon.