### PR TITLE
Statically choose lowest (least lossy) compression for JPEG and TIFF

### DIFF
--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -845,8 +845,18 @@ escl_scan_query (const proto_ctx *ctx)
     //xml_wr_add_text(xml, "scan:InputSource", source);
     xml_wr_add_text(xml, "pwg:InputSource", source);
     if (ctx->devcaps->compression_ok) {
-        xml_wr_add_uint(xml, "scan:CompressionFactor",
-            ctx->devcaps->compression_norm);
+        /* If the format is JPEG or TIFF (which can have embedded JPEG),
+         * prioritize quality over size.
+         */
+        if (ctx->params.format == ID_FORMAT_JPEG ||
+            ctx->params.format == ID_FORMAT_TIFF) {
+            xml_wr_add_uint(xml, "scan:CompressionFactor",
+                ctx->devcaps->compression_range.min);
+        }
+        else {
+            xml_wr_add_uint(xml, "scan:CompressionFactor",
+                ctx->devcaps->compression_norm);
+        }
     }
     xml_wr_add_text(xml, "scan:ColorMode", colormode);
     xml_wr_add_text(xml, "pwg:DocumentFormat", mime);


### PR DESCRIPTION
This may be opinionated, but I would claim it's in practice better than the default. :-) I didn't dig far enough into SANE to understand if this can be exposed as an option; in any case, I'd argue it's even a _better default_.

# Changes

1. Previously the format preference order was PNG, JPEG, TIFF, BMP; choose the first one that the scanner supports. Change it to PNG, TIFF, BMP, JPEG. Rationale: JPEG is almost certainly lossy. TIFF and BMP can be lossless. (Hmm, is there a lossy BMP?)

Now, it turns out my scanner, ET-8550, only offers to produce JPEG and PDF, so this part is... actually untested for effect. Dropping it would be fair, or I can put it in a separate PR if you prefer. At least it doesn't break anything for me.

2. The scanner reports the compression levels it supports. eSCL defines these so that lower numbers mean less compression (less lossy). Here's what I get from ET-8550:

```xml
  <scan:CompressionFactorSupport>
    <scan:Min>1</scan:Min>
    <scan:Max>3</scan:Max>
    <scan:Normal>2</scan:Normal>
    <scan:Step>1</scan:Step>
  </scan:CompressionFactorSupport>
  ```

`escl_scan_query` sets the requested compression to the "Normal" value. This PR changes it to set it to the "Min" value. Rationale: network and communication are cheap; all SANE pipelines I know of take the pixel data anyway and, if saved in a lossy format, recompress it (there might be a point to avoiding recompression if it was reasonably possible to save the JPEG that the scanner sends as is), cumulating the lossiness.

# Practical effects of the JPEG quality change

## Transfer size

I made a scan of the same document before and after, without touching the flatbed scanner in between, with

`scanimage -d "airscan:e0:EPSON ET-8550 Series" --resolution 300 -x 210 -y 297 -o test.png`

before and after this change, capturing the traffic with the `airscan.conf` debug/trace functionality, with an ET-8550 connected over WLAN. The JPEG sent before was 806,713 bytes in size; after the change, the JPEG sent is 1,906,351 bytes.

## Scan time

Any difference in scan time seems to be completely lost in noise, and I couldn't tease any meaningful difference with a few tries. Here are two runs, based on timestamps in `scanimage-EPSON-ET-8550-Series.log`, times from command start (timestamps from the log), with total time until that point and time from the previous milestone:

|  Event  | Time before change |  Time after change |
| ------------- | ------------- |  ------------- |
| Last `HTTP done request sending` before scan  | 1.578 s | 1.717 s |
| `HTTP GET: got response headers (200)` for image data | 6.023 s (prev + 4.445 s)|  6.156 s (prev + 4.439 s) |
| `HTTP done response reception` | 14.029 s  (prev + 8.006 s) | 14.159 s (prev + 8.003 s) |

Here the biggest difference seems to be in how fast the initial connection was formed to the device, which is unlikely to be affected by this change. Otherwise, in this random pair of runs, the scan completed actually slightly faster (certainly due to noise).

## Image quality

Here are some zoomed in parts of the JPEGs sent by the scanner and saved by the backend trace to show the quality difference (300% zoom, no interpolation).

Notice that this document has some inherent noise (it's a printer test target, after all). I tried to take parts that show both the compression effect on that printer noise and on text.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/91e62f82-2eb0-4f30-946c-af6ac152eb7d) | ![image](https://github.com/user-attachments/assets/aa7451cc-ed14-4617-9b87-3bb6e252f904) |
| ![image](https://github.com/user-attachments/assets/937998eb-46c7-49ff-a041-2c3c0dcb7da0) | ![image](https://github.com/user-attachments/assets/a203d093-c798-4ca5-b651-2d13df7d9cd9) | 

Full scans:

![new](https://github.com/user-attachments/assets/ac340f3d-1ed0-4da3-9c98-748f7705f53f)
![old](https://github.com/user-attachments/assets/08b496dc-bdb6-42e4-9c7c-a44c38279b9d)
