### PR TITLE
Add EPSON EW-M752T to support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Legend:
 | EPSON ET-4750 Series               | No                        | Yes                       |
 | EPSON ET-4850 Series               | Yes                       |                           |
 | EPSON ET-M2170 Series              | Yes                       |                           |
+| EPSON EW-M752T Series              | No                        | Yes                       |
 | EPSON L6570 Series                 | Yes                       | Yes                       |
 | EPSON Stylus SX535WD               | No                        | Yes                       |
 | EPSON WF-2760 Series               |                           | Yes                       |


### PR DESCRIPTION
WSD is detected and works. eSCL is not detected by airscan-discover(1).