### PR TITLE
Documented Canon MF660C Series support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Legend:
 | Canon MF440 Series                 | Yes                       | Yes                       |
 | Canon MF645Cx                      | Yes                       |                           |
 | Canon MF650C Series                | Yes                       |                           |
+| Canon MF660C Series                | Yes                       |                           |
 | Canon MF745C/746C                  | Yes                       | Yes                       |
 | Canon MG5200 series                | No                        | Yes                       |
 | Canon MG5300 series                | No                        | Yes                       |


### PR DESCRIPTION
Tested and documented support for Canon MF660C series. Tested on a Canon MF663dw AIO device. 