### PR TITLE
Document support for Brother DCP-L2530DW

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Legend:
 | Brother DCP-7070DW                 | No                        | Yes                       |
 | Brother DCP-9020CDW                | No                        | Yes                       |
 | Brother DCP-J552DW                 | No                        | Yes                       |
+| Brother DCP-L2530DW                | Yes                       | Yes                       |
 | Brother DCP-L2540DW                | No                        | Yes                       |
 | Brother DCP-L2550DN / DCP-L2550DW  | Yes                       |                           |
 | Brother DCP-L2660DW                | Yes                       |                           |


### PR DESCRIPTION
Works for me using either protocol.

Interestingly, eSCL (according to xsane) supports scanning with 100, 200, 300, 600 DPI, whereas WSD only supports 100, 200, 300 DPI.

The vendor-provided driver (brscan4 0.4.11-1) advertises DPIs of 100, 150, 200, 300, 400, 600, 1200, 2400, 4800, 9600.
