### PR TITLE
Add an erroneously absent verb to one sentence in two files.

### DIFF
--- a/sane-airscan.5
+++ b/sane-airscan.5
@@ -32,7 +32,7 @@ variable 2 = value 2
 .P
 Leading and trailing spaces of variable name and value are striped\. If you want to preserve them, put name or value into quotes ("like this")\.
 .SH "CONFIGURATION OF DEVICES"
-If scanner and computer are connected to the same LAN segment, everything expected to "just work" out of box, without any need of manual configuration\.
+If scanner and computer are connected to the same LAN segment, everything is expected to "just work" out of box, without any need of manual configuration\.
 .P
 However, in some cases manual configuration can be useful\. For example:
 .IP "" 4

--- a/sane-airscan.5.md
+++ b/sane-airscan.5.md
@@ -30,7 +30,7 @@ If you want to preserve them, put name or value into quotes ("like this").
 
 ## CONFIGURATION OF DEVICES
 
-If scanner and computer are connected to the same LAN segment, everything
+If scanner and computer are connected to the same LAN segment, everything is
 expected to "just work" out of box, without any need of manual configuration.
 
 However, in some cases manual configuration can be useful. For example:


### PR DESCRIPTION
A stative linking verb (“is”) was erroneously absent.