### PR TITLE
Added Xerox C315 support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Legend:
 | Xerox B205                         | Yes                       | Yes                       |
 | Xerox B215                         | Yes                       | Yes<sup>[10](#note10)</sup>|
 | Xerox C235                         | Yes                       |                           |
+| Xerox C315                         | Yes                       | Yes                       |
 | Xerox VersaLink B405               | Yes                       |                           |
 | Xerox WorkCentre 3025              | No                        | Yes                       |
 | Xerox WorkCentre 6027              | No                        | Yes<sup>[10](#note10)</sup>|


### PR DESCRIPTION
I tested a Xerox C315 with the following config:

```
[devices]
"Xerox C315 Color MFP eSCL" = http://xerox-c315.example.com/eSCL, eSCL
"Xerox C315 Color MFP WSD" = http://xerox-c315.example.com/WSDScanner, WSD
```

Only the eSCL mode entry worked. I'm not 100% sure that the WSD path is correct, I just copied the example from the manpage.