### PR TITLE
escl: reject eSCL 1.0 devices gracefully instead of asserting (fixes the #299 SIGABRT)

### DIFF
--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -324,24 +324,6 @@ escl_devcaps_source_parse_setting_profiles (xml_rd *xml, devcaps_source *src)
     }
     xml_rd_leave(xml);
 
-    /* Validate results */
-    if (err == NULL) {
-        src->colormodes &= DEVCAPS_COLORMODES_SUPPORTED;
-        if (src->colormodes == 0) {
-            return ERROR("no color modes detected");
-        }
-
-        src->formats &= DEVCAPS_FORMATS_SUPPORTED;
-        if (src->formats == 0) {
-            return ERROR("no image formats detected");
-        }
-
-        if (!(src->flags & (DEVCAPS_SOURCE_RES_DISCRETE|
-                            DEVCAPS_SOURCE_RES_RANGE))){
-            return ERROR("scan resolutions are not defined");
-        }
-    }
-
     return err;
 }
 
@@ -441,6 +423,31 @@ escl_devcaps_source_parse (xml_rd *xml, devcaps_source **out)
     xml_rd_leave(xml);
 
     if (err != NULL) {
+        goto DONE;
+    }
+
+    /* Validate color modes, formats and resolutions. These are parsed from
+     * <scan:SettingProfiles> (eSCL 2.x). eSCL 1.0 devices don't have that
+     * node (their capabilities live under top-level <scan:ColorProfiles>),
+     * so a source can reach this point with none of them set. Reject such a
+     * source with an error here, rather than accepting it and later hitting
+     * the assertion in devopt_choose_colormode() (an unsupported eSCL 1.0
+     * device must fail gracefully, not abort the whole backend).
+     */
+    src->colormodes &= DEVCAPS_COLORMODES_SUPPORTED;
+    if (src->colormodes == 0) {
+        err = ERROR("no color modes detected");
+        goto DONE;
+    }
+
+    src->formats &= DEVCAPS_FORMATS_SUPPORTED;
+    if (src->formats == 0) {
+        err = ERROR("no image formats detected");
+        goto DONE;
+    }
+
+    if (!(src->flags & (DEVCAPS_SOURCE_RES_DISCRETE|DEVCAPS_SOURCE_RES_RANGE))) {
+        err = ERROR("scan resolutions are not defined");
         goto DONE;
     }
 


### PR DESCRIPTION
### Problem

Opening a device that speaks **eSCL 1.0** aborts the backend with a SIGABRT:

```
airscan-devops.c: line 130 (devopt_choose_colormode): assertion failed: (wanted < NUM_ID_COLORMODE)
```

This is the crash from #299 (there closed as "won't add eSCL 1.0 support"). You noted there that you'd already fixed the assertion so such devices are *rejected with an error* rather than aborting -- but on current `master` the assertion is still reachable. I reproduced it with an **HP Color LaserJet MFP M476dw** (eSCL 1.0) on 0.99.29 and on a fresh build of `master`.

### Root cause

eSCL 1.0 devices advertise color modes / formats / resolutions under a top-level `<scan:ColorProfiles>` element instead of the eSCL 2.x `<scan:SettingProfiles>`. `escl_devcaps_source_parse_setting_profiles()` is the only place those are read, **and** it's where the "no color modes / no formats / no resolutions" validation lived. For an eSCL 1.0 device that node is absent, so the source is accepted with `colormodes == 0`, and `devopt_choose_colormode()` later asserts.

### Fix

Move that validation out of the SettingProfiles parser and into `escl_devcaps_source_parse()`, so every source is validated regardless of whether `<scan:SettingProfiles>` was present. An unsupported eSCL 1.0 source is now rejected with a normal error ("no color modes detected") instead of aborting. This is scoped strictly to turning the crash into a graceful rejection -- it does **not** attempt to add eSCL 1.0 support.

### Testing

Against the M476dw's real `ScannerCapabilities` (eSCL 1.0):

| | before | after |
|---|---|---|
| `test-devcaps -escl` | prints source with empty color modes | `error: no color modes detected` |
| `scanimage -A` (open) | **SIGABRT** (exit 134) | clean error (exit 1) |

Regression check: the same printer also exposes **WSD**, and `scanimage -A` over WSD still succeeds (Color/Gray, 75/150/300 dpi, Flatbed/ADF/ADF-Duplex) both before and after -- so with this fix airscan degrades to the working WSD path instead of crashing on the eSCL 1.0 interface. eSCL 2.x devices are unaffected (same validation, just relocated).
