### PR TITLE
Add RICOH SP C261SFNw (potentially more RICOH devices too) support

### DIFF
--- a/airscan-device.c
+++ b/airscan-device.c
@@ -443,11 +443,6 @@ device_proto_op_submit (device *dev, PROTO_OP op,
         timeout = DEVICE_HTTP_TIMEOUT_SCAN;
         break;
 
-    case PROTO_OP_PRELOAD:
-        func = dev->proto_ctx.proto->status_query;
-        timeout = DEVICE_HTTP_TIMEOUT_CHECK;
-        break;
-
     case PROTO_OP_LOAD:
         func = dev->proto_ctx.proto->load_query;
         timeout = DEVICE_HTTP_TIMEOUT_LOAD;

--- a/airscan-device.c
+++ b/airscan-device.c
@@ -443,6 +443,11 @@ device_proto_op_submit (device *dev, PROTO_OP op,
         timeout = DEVICE_HTTP_TIMEOUT_SCAN;
         break;
 
+    case PROTO_OP_PRELOAD:
+        func = dev->proto_ctx.proto->status_query;
+        timeout = DEVICE_HTTP_TIMEOUT_CHECK;
+        break;
+
     case PROTO_OP_LOAD:
         func = dev->proto_ctx.proto->load_query;
         timeout = DEVICE_HTTP_TIMEOUT_LOAD;

--- a/airscan-device.c
+++ b/airscan-device.c
@@ -443,6 +443,11 @@ device_proto_op_submit (device *dev, PROTO_OP op,
         timeout = DEVICE_HTTP_TIMEOUT_SCAN;
         break;
 
+    case PROTO_OP_PRELOAD:
+        func = dev->proto_ctx.proto->status_query;
+        timeout = DEVICE_HTTP_TIMEOUT_CHECK;
+        break;
+
     case PROTO_OP_LOAD:
         func = dev->proto_ctx.proto->load_query;
         timeout = DEVICE_HTTP_TIMEOUT_LOAD;
@@ -500,6 +505,7 @@ device_proto_op_decode (device *dev, PROTO_OP op)
     case PROTO_OP_NONE:    log_internal_error(dev->log); break;
     case PROTO_OP_PRECHECK:func = dev->proto_ctx.proto->precheck_decode; break;
     case PROTO_OP_SCAN:    func = dev->proto_ctx.proto->scan_decode; break;
+    case PROTO_OP_PRELOAD: func = dev->proto_ctx.proto->status_decode; break;
     case PROTO_OP_LOAD:    func = dev->proto_ctx.proto->load_decode; break;
     case PROTO_OP_CHECK:   func = dev->proto_ctx.proto->status_decode; break;
     case PROTO_OP_CLEANUP: func = device_proto_dummy_decode; break;

--- a/airscan-device.c
+++ b/airscan-device.c
@@ -500,7 +500,6 @@ device_proto_op_decode (device *dev, PROTO_OP op)
     case PROTO_OP_NONE:    log_internal_error(dev->log); break;
     case PROTO_OP_PRECHECK:func = dev->proto_ctx.proto->precheck_decode; break;
     case PROTO_OP_SCAN:    func = dev->proto_ctx.proto->scan_decode; break;
-    case PROTO_OP_PRELOAD: func = dev->proto_ctx.proto->status_decode; break;
     case PROTO_OP_LOAD:    func = dev->proto_ctx.proto->load_decode; break;
     case PROTO_OP_CHECK:   func = dev->proto_ctx.proto->status_decode; break;
     case PROTO_OP_CLEANUP: func = device_proto_dummy_decode; break;

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -574,6 +574,10 @@ escl_devcaps_parse (proto_handler_escl *escl,
             } else if (!strcmp(m, "MF410 Series")) {
                 escl->quirk_check_adf_state = true;
             } else if (!strcmp(m, "RICOH")) {
+                /* Some RICOH devices require ScannerStatus to be
+                 queried after ScanJobs and before NextDocument. Otherwise,
+                 the job remains in the Pending state indefinitely.
+                 */
                 escl->quirk_status_before_load = true;
             } else if (!strncasecmp(m, "EPSON ", 6)) {
                 escl->quirk_port_in_host = true;

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -1201,18 +1201,16 @@ escl_status_decode (const proto_ctx *ctx)
     bool               temporary = false;
 
     if (ctx->op == PROTO_OP_PRELOAD) {
-        proto_result preload = {0};
-
-        preload.err = http_query_error(ctx->query);
-        if (preload.err != NULL) {
-            preload.status = SANE_STATUS_IO_ERROR;
-            preload.next = PROTO_OP_CLEANUP;
+        result.err = http_query_error(ctx->query);
+        if (result.err != NULL) {
+            result.status = SANE_STATUS_IO_ERROR;
+            result.next = PROTO_OP_CLEANUP;
         } else {
-            preload.status = SANE_STATUS_GOOD;
-            preload.next = PROTO_OP_LOAD;
+            result.status = SANE_STATUS_GOOD;
+            result.next = PROTO_OP_LOAD;
         }
 
-        return preload;
+        return result;
     }
 
     /* Decode status */

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -53,6 +53,7 @@ typedef struct {
     /* Miscellaneous flags */
     bool quirk_localhost;            /* Set Host: localhost in ScanJobs rq */
     bool quirk_check_adf_state;      /* Check ADF state before scan */
+    bool quirk_status_before_load;   /* Query status before NextDocument */
     bool quirk_port_in_host;         /* Always set port in Host: header */
     bool quirk_next_load_delay;      /* Use ESCL_NEXT_LOAD_DELAY */
     bool quirk_retry_on_404;         /* Retry GET NextDocunemt on HTTP 404 */
@@ -572,6 +573,8 @@ escl_devcaps_parse (proto_handler_escl *escl,
                 escl->quirk_localhost = true;
             } else if (!strcmp(m, "MF410 Series")) {
                 escl->quirk_check_adf_state = true;
+            } else if (!strcmp(m, "RICOH")) {
+                escl->quirk_status_before_load = true;
             } else if (!strncasecmp(m, "EPSON ", 6)) {
                 escl->quirk_port_in_host = true;
             } else if (!strncasecmp(m, "Brother ", 8)) {
@@ -997,7 +1000,8 @@ escl_scan_decode (const proto_ctx *ctx)
     result.data.location = str_dup(http_uri_str(uri));
     http_uri_free(uri);
 
-    result.next = PROTO_OP_LOAD;
+    result.next = escl->quirk_status_before_load ?
+        PROTO_OP_PRELOAD : PROTO_OP_LOAD;
 
     return result;
 
@@ -1195,6 +1199,21 @@ escl_status_decode (const proto_ctx *ctx)
     SANE_Status        status;
     int                max_attempts;
     bool               temporary = false;
+
+    if (ctx->op == PROTO_OP_PRELOAD) {
+        proto_result preload = {0};
+
+        preload.err = http_query_error(ctx->query);
+        if (preload.err != NULL) {
+            preload.status = SANE_STATUS_IO_ERROR;
+            preload.next = PROTO_OP_CLEANUP;
+        } else {
+            preload.status = SANE_STATUS_GOOD;
+            preload.next = PROTO_OP_LOAD;
+        }
+
+        return preload;
+    }
 
     /* Decode status */
     err = http_query_error(ctx->query);

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -1001,7 +1001,7 @@ escl_scan_decode (const proto_ctx *ctx)
     http_uri_free(uri);
 
     result.next = escl->quirk_status_before_load ?
-        PROTO_OP_CHECK : PROTO_OP_LOAD;
+        PROTO_OP_PRELOAD : PROTO_OP_LOAD;
 
     return result;
 
@@ -1200,7 +1200,7 @@ escl_status_decode (const proto_ctx *ctx)
     int                max_attempts;
     bool               temporary = false;
 
-    if (ctx->op == PROTO_OP_CHECK) {
+    if (ctx->op == PROTO_OP_PRELOAD) {
         proto_result preload = {0};
 
         preload.err = http_query_error(ctx->query);

--- a/airscan-escl.c
+++ b/airscan-escl.c
@@ -1001,7 +1001,7 @@ escl_scan_decode (const proto_ctx *ctx)
     http_uri_free(uri);
 
     result.next = escl->quirk_status_before_load ?
-        PROTO_OP_PRELOAD : PROTO_OP_LOAD;
+        PROTO_OP_CHECK : PROTO_OP_LOAD;
 
     return result;
 
@@ -1200,7 +1200,7 @@ escl_status_decode (const proto_ctx *ctx)
     int                max_attempts;
     bool               temporary = false;
 
-    if (ctx->op == PROTO_OP_PRELOAD) {
+    if (ctx->op == PROTO_OP_CHECK) {
         proto_result preload = {0};
 
         preload.err = http_query_error(ctx->query);

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -242,7 +242,6 @@ static id_name_table proto_op_name_table[] = {
     {PROTO_OP_NONE,     "PROTO_OP_NONE"},
     {PROTO_OP_PRECHECK, "PROTO_OP_PRECHECK"},
     {PROTO_OP_SCAN,     "PROTO_OP_SCAN"},
-    {PROTO_OP_PRELOAD,  "PROTO_OP_PRELOAD"},
     {PROTO_OP_LOAD,     "PROTO_OP_LOAD"},
     {PROTO_OP_CHECK,    "PROTO_OP_CHECK"},
     {PROTO_OP_CLEANUP,  "PROTO_OP_CLEANUP"},

--- a/airscan-id.c
+++ b/airscan-id.c
@@ -242,6 +242,7 @@ static id_name_table proto_op_name_table[] = {
     {PROTO_OP_NONE,     "PROTO_OP_NONE"},
     {PROTO_OP_PRECHECK, "PROTO_OP_PRECHECK"},
     {PROTO_OP_SCAN,     "PROTO_OP_SCAN"},
+    {PROTO_OP_PRELOAD,  "PROTO_OP_PRELOAD"},
     {PROTO_OP_LOAD,     "PROTO_OP_LOAD"},
     {PROTO_OP_CHECK,    "PROTO_OP_CHECK"},
     {PROTO_OP_CLEANUP,  "PROTO_OP_CLEANUP"},

--- a/airscan.h
+++ b/airscan.h
@@ -3294,6 +3294,7 @@ typedef enum {
     PROTO_OP_NONE,    /* No operation */
     PROTO_OP_PRECHECK,/* Pre-scan check */
     PROTO_OP_SCAN,    /* New scan */
+    PROTO_OP_PRELOAD, /* Pre-load synchronization */
     PROTO_OP_LOAD,    /* Load image */
     PROTO_OP_CHECK,   /* Check device status */
     PROTO_OP_CLEANUP, /* Cleanup after scan */

--- a/airscan.h
+++ b/airscan.h
@@ -3294,7 +3294,6 @@ typedef enum {
     PROTO_OP_NONE,    /* No operation */
     PROTO_OP_PRECHECK,/* Pre-scan check */
     PROTO_OP_SCAN,    /* New scan */
-    PROTO_OP_PRELOAD, /* Pre-load synchronization */
     PROTO_OP_LOAD,    /* Load image */
     PROTO_OP_CHECK,   /* Check device status */
     PROTO_OP_CLEANUP, /* Cleanup after scan */


### PR DESCRIPTION
This fixes the scanning issues for RICOH SP C261SFNw. In order to work, RICOH requires a ScannerStatus request to be sent between creating the scan job and retrieving the actual image; the printer stays in the Pending state otherwise.